### PR TITLE
Add persistent logging writer, CLI, and operational docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .DS_Store
+.imme/

--- a/README.md
+++ b/README.md
@@ -30,3 +30,19 @@ const logger = new StructuredLogger({
 
 logger.info({ message: "Boot sequence complete", functionName: "main" });
 ```
+
+## CLI logging tool
+
+Install the CLI locally to emit structured logs from the terminal:
+
+```bash
+npm link
+imme log --message "hello" --filename cli.js
+```
+
+Entries are appended to `.imme/logs.jsonl` by default. The CLI accepts
+additional context fields (`--system-section`, `--method`, `--db-phase`, etc.)
+that match the canonical log schema.
+
+Refer to `docs/runbook.md` for operational procedures and
+`docs/onboarding.md` for contributor guidelines.

--- a/bin/imme.js
+++ b/bin/imme.js
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+
+import { basename, join, resolve } from "node:path";
+import process from "node:process";
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+
+import {
+  StructuredLogger,
+  createPersistentFileWriter
+} from "../src/index.js";
+
+const require = createRequire(import.meta.url);
+const pkg = require("../package.json");
+
+const DEFAULT_RELATIVE_LOG_PATH = join(".imme", "logs.jsonl");
+
+function printUsage() {
+  const scriptName = getScriptName();
+  console.log(`Imme CLI v${pkg.version}`);
+  console.log("");
+  console.log("Usage:");
+  console.log(`  ${scriptName} log --message <text> [options]`);
+  console.log("");
+  console.log("Options:");
+  console.log("  --message, -m         Log message to emit (required)");
+  console.log("  --level, -l           Log level: info, debug, error (default: info)");
+  console.log("  --filename            Source filename for the log entry");
+  console.log("  --classname           Class name producing the log entry");
+  console.log("  --function            Function name producing the log entry");
+  console.log("  --system-section      Logical system section name");
+  console.log("  --method              HTTP method context (GET, POST, DELETE, PUT)");
+  console.log("  --db-phase            Database phase context (pre, post)");
+  console.log("  --log-file            Override persistent log file path");
+  console.log("  --dry-run             Skip writing to persistent log storage");
+  console.log("  --help                Show this message");
+  console.log("  --version             Print version information");
+}
+
+function getScriptName() {
+  const scriptPath = process.argv[1];
+  return scriptPath ? basename(scriptPath) : "imme";
+}
+
+function parseArgs(rawArgs) {
+  const args = [...rawArgs];
+  let command = "log";
+  const options = {};
+
+  if (args.length > 0 && !args[0].startsWith("-")) {
+    command = args.shift();
+  }
+
+  while (args.length > 0) {
+    const token = args.shift();
+    if (token === "--help" || token === "-h") {
+      options.help = true;
+      continue;
+    }
+
+    if (token === "--version" || token === "-v") {
+      options.version = true;
+      continue;
+    }
+
+    if (token === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+
+    if (token.startsWith("--")) {
+      const key = token.slice(2);
+      const next = args.shift();
+      if (next === undefined || next.startsWith("-")) {
+        throw new Error(`Option --${key} requires a value`);
+      }
+      options[key] = next;
+      continue;
+    }
+
+    if (token.startsWith("-")) {
+      const shorthand = token.slice(1);
+      const next = args.shift();
+      if (next === undefined || next.startsWith("-")) {
+        throw new Error(`Option -${shorthand} requires a value`);
+      }
+      switch (shorthand) {
+        case "m":
+          options.message = next;
+          break;
+        case "l":
+          options.level = next;
+          break;
+        default:
+          throw new Error(`Unknown shorthand option -${shorthand}`);
+      }
+      continue;
+    }
+
+    throw new Error(`Unexpected argument: ${token}`);
+  }
+
+  return { command, options };
+}
+
+function normalizeLevel(value = "info") {
+  const normalized = String(value).toLowerCase();
+  if (["info", "debug", "error"].includes(normalized)) {
+    return normalized;
+  }
+
+  return "info";
+}
+
+function resolveLogFilePath(optionValue) {
+  const resolved = resolve(process.cwd(), optionValue ?? DEFAULT_RELATIVE_LOG_PATH);
+  return resolved;
+}
+
+function filterUndefinedEntries(entries) {
+  const result = {};
+  for (const [key, value] of Object.entries(entries)) {
+    if (value !== undefined && value !== null && value !== "") {
+      result[key] = value;
+    }
+  }
+
+  return result;
+}
+
+function main() {
+  let parsed;
+  try {
+    parsed = parseArgs(process.argv.slice(2));
+  } catch (error) {
+    console.error(error.message);
+    printUsage();
+    process.exitCode = 1;
+    return;
+  }
+
+  const { command, options } = parsed;
+
+  if (options.help) {
+    printUsage();
+    return;
+  }
+
+  if (options.version) {
+    console.log(pkg.version);
+    return;
+  }
+
+  if (command !== "log") {
+    console.error(`Unknown command: ${command}`);
+    printUsage();
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!options.message) {
+    console.error("--message is required for the log command");
+    printUsage();
+    process.exitCode = 1;
+    return;
+  }
+
+  const level = normalizeLevel(options.level);
+  const logFilePath = resolveLogFilePath(options["log-file"]);
+
+  let persistentWriter;
+  if (!options.dryRun) {
+    try {
+      persistentWriter = createPersistentFileWriter({ filePath: logFilePath });
+    } catch (error) {
+      console.error(`Failed to create persistent log writer: ${error.message}`);
+      process.exitCode = 1;
+      return;
+    }
+  } else {
+    persistentWriter = {
+      log() {},
+      write() {}
+    };
+  }
+
+  const baseContext = filterUndefinedEntries({
+    filename: options.filename,
+    classname: options.classname,
+    functionName: options.function,
+    systemSection: options["system-section"],
+    method: options.method,
+    dbPhase: options["db-phase"]
+  });
+
+  if (Object.keys(baseContext).length === 0) {
+    baseContext.filename = "imme-cli";
+  }
+
+  const logger = new StructuredLogger({
+    persistentWriter,
+    baseContext
+  });
+
+  const entryContext = filterUndefinedEntries({
+    message: options.message,
+    functionName: options.function,
+    systemSection: options["system-section"],
+    method: options.method,
+    dbPhase: options["db-phase"],
+    classname: options.classname
+  });
+
+  const methodName = level === "error" ? "error" : level;
+  logger[methodName](entryContext);
+
+  if (!options.dryRun && !existsSync(logFilePath)) {
+    console.error(`Warning: log file was not created at ${logFilePath}`);
+    process.exitCode = 1;
+  }
+}
+
+main();

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -1,0 +1,108 @@
+# Domain Model & Persistence Requirements
+
+The Imme workspace tracks project delivery efforts across three primary concerns:
+
+1. **Operational logs** that capture activity from tools and services.
+2. **Work management artifacts** (projects, tasks, and workflows).
+3. **Knowledge assets** such as runbooks and onboarding documentation.
+
+This document defines the initial domain model and the accompanying persistence
+expectations so that future features can build on a shared vocabulary.
+
+## Core Entities
+
+### ProjectWorkspace
+
+Represents the root of the Imme environment. A workspace owns the configuration
+for logging, file locations, and default CLI behaviors.
+
+| Field | Description |
+| --- | --- |
+| `id` | Stable identifier (UUID). |
+| `name` | Human friendly workspace name. |
+| `defaultLogPath` | Absolute path to the JSONL log file used by the CLI. |
+| `createdAt` | ISO-8601 timestamp of workspace creation. |
+
+Persistence: stored as a configuration document (`workspace.json`) within the
+repository so that new contributors inherit the defaults immediately.
+
+### Project
+
+Captures a unit of delivery inside the workspace.
+
+| Field | Description |
+| --- | --- |
+| `id` | UUID. |
+| `name` | Project name (e.g., "CLI Rollout"). |
+| `description` | Narrative summary of scope and context. |
+| `status` | Enum: `proposed`, `active`, `complete`. |
+| `createdAt` / `updatedAt` | ISO-8601 timestamps. |
+
+Persistence: near-term storage uses Markdown in `project-manager/` for human
+review. When a database is introduced, projects map cleanly to a relational
+table with unique IDs and timestamp metadata.
+
+### Task
+
+Represents a work item belonging to a project.
+
+| Field | Description |
+| --- | --- |
+| `id` | UUID. |
+| `projectId` | Foreign key to `Project`. |
+| `title` | Concise task title. |
+| `status` | Enum: `todo`, `in_progress`, `blocked`, `done`. |
+| `assignees` | Array of contributor identifiers. |
+| `notes` | Free-form Markdown notes, often referencing commit hashes. |
+| `createdAt` / `updatedAt` | ISO-8601 timestamps. |
+
+Persistence: Markdown checklists remain authoritative until a task tracker is
+implemented. The schema deliberately matches a future SQLite table so that a
+transparent migration path exists.
+
+### LogEntry
+
+Structured record emitted by automation (CLI, services) that follows the
+canonical schema defined in `StructuredLogger`.
+
+| Field | Description |
+| --- | --- |
+| `timestamp` | ISO-8601 string (UTC). |
+| `level` | `DEBUG`, `INFO`, or `ERROR`. |
+| `filename` | Originating source file. |
+| `classname` | Optional class or module name. |
+| `function` | Optional function name. |
+| `system_section` | Logical domain component (e.g., `startup`). |
+| `line_num` | Optional source line number (integer). |
+| `method` | HTTP method context (`GET`, `POST`, `DELETE`, `PUT`, `NONE`). |
+| `db_phase` | Database interaction phase (`pre`, `post`, `none`). |
+| `message` | Human-readable summary. |
+| `error` | Structured error payload when applicable. |
+
+Persistence: appended to a JSON Lines (JSONL) file with one object per line to
+support streaming analytics and log rotation. Log retention policies are
+managed via operating runbooks.
+
+## Persistence Requirements
+
+1. **Durability**: Persistent logs must survive process restarts. The
+   `createPersistentFileWriter` utility appends to disk synchronously to avoid
+   data loss in the presence of abrupt exits.
+2. **Portability**: All data formats remain text-based (`.json`, `.jsonl`,
+   Markdown) to support Git-based workflows and diff review.
+3. **Isolation**: Environment-specific data (e.g., generated logs) lives under
+   the workspace `.imme/` directory so that developers can opt-in to sharing it
+   via `.gitignore` rules.
+4. **Forward Compatibility**: Schemas mirror traditional relational tables so
+   that migration to SQLite or Postgres can occur without rewriting business
+   logic. UUIDs are mandated across entities to simplify replication and
+   distributed workflows.
+
+## Future Considerations
+
+- Introduce an event-sourcing stream for CLI actions so that automation can
+  rebuild state from log history.
+- Leverage SQLite for storing workspace, project, and task entities while
+  maintaining JSONL logs for append-only record keeping.
+- Expose persistence configuration through the CLI (`imme config`) once more
+  services depend on the data model.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,0 +1,71 @@
+# Developer Onboarding Guide
+
+Welcome to the Imme project! This guide helps new contributors become
+productive quickly by outlining environment setup, workflows, and key
+capabilities.
+
+## 1. Prerequisites
+
+- **Node.js 20+**: The codebase uses ESM modules and Node's built-in test
+  runner. Install via [fnm](https://github.com/Schniz/fnm) or the official
+  binaries.
+- **npm 10+**: Bundled with Node 20, used for dependency management.
+- **ripgrep**: Preferred search tool for inspecting large repositories.
+
+## 2. Workspace Setup
+
+```sh
+git clone <repo-url>
+cd imme
+npm install
+```
+
+The project intentionally keeps dependencies light; the only direct dependencies
+are `eslint` and `@eslint/js` for linting.
+
+## 3. Useful Commands
+
+- `npm test` – Executes the Node.js test suite (`node --test`).
+- `npm run lint` – Runs ESLint across the repo using the shared configuration.
+- `imme log --help` – Lists CLI commands and options.
+
+Add the CLI to your path during development:
+
+```sh
+npm link
+imme --help
+```
+
+## 4. Logging Workflow
+
+1. Invoke the CLI to emit structured logs:
+   ```sh
+   imme log --message "boot" --filename server.js --system-section startup
+   ```
+2. Inspect persistent logs at `.imme/logs.jsonl`. Each line is a JSON object
+   suitable for ingestion by log processors.
+3. When testing without touching disk, append `--dry-run` to CLI commands.
+
+## 5. Coding Guidelines
+
+- Favor small, focused modules and avoid unnecessary dependencies.
+- Follow the canonical log schema: never omit `filename` and `message` when
+  emitting entries.
+- Document intent in comments, not just behavior.
+- Write tests alongside features. Code without tests is considered incomplete.
+
+## 6. Pull Request Expectations
+
+- Include a summary of changes and reference related tasks in
+  `project-manager/task.md`.
+- Ensure `npm test` and `npm run lint` pass locally before pushing.
+- Provide links to relevant runbook sections when introducing operational
+  features.
+
+## 7. Next Steps
+
+- Review `docs/domain-model.md` to understand the core entities.
+- Browse `docs/runbook.md` for operational procedures and escalation paths.
+- Coordinate ongoing work via the task tracker in `project-manager/task.md`.
+
+Welcome aboard!

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,63 @@
+# Operations Runbook
+
+This runbook describes how to operate the Imme workspace day-to-day. It focuses
+on logging, troubleshooting, and maintenance procedures that leverage the
+structured logging utilities delivered by the CLI.
+
+## Daily Checklist
+
+1. **Review Logs**
+   - Run `imme log --message "health-check" --level debug --dry-run` to confirm
+     the CLI works without touching persistent storage.
+   - Inspect `.imme/logs.jsonl` for overnight errors using tools such as
+     `rg "ERROR" .imme/logs.jsonl`.
+2. **Rotate Logs (Weekly)**
+   - Archive the current log file: `mv .imme/logs.jsonl .imme/logs-$(date +%F).jsonl`.
+   - Touch a new file so permissions remain consistent: `imme log --message "log rotation"`.
+3. **Validate Structured Output**
+   - Spot check for the derived line prefix `[Continuous skepticism (Sherlock Protocol)]` in console output.
+
+## Incident Response
+
+1. **Capture Context**
+   - Use the CLI to record an incident marker, supplying as much context as
+     possible:
+     ```sh
+     imme log --level error --message "API outage" \
+       --filename incident-handler.js \
+       --system-section production --method GET --db-phase post
+     ```
+2. **Analyze Recent Entries**
+   - Parse the JSONL log with `jq` to filter entries:
+     ```sh
+     jq 'select(.level == "ERROR")' .imme/logs.jsonl | tail
+     ```
+3. **Document Findings**
+   - Update `project-manager/task.md` with follow-up actions or new tasks.
+
+## Maintenance Procedures
+
+- **Permissions**: Logs are created with `0600` permissions to protect sensitive
+  data. When sharing logs, strip secrets and adjust permissions explicitly.
+- **Backups**: Copy `.imme/logs.jsonl` into secure storage before destructive
+  testing. The log format is append-only and can be replayed by future services.
+- **Configuration Changes**: Update the workspace configuration file (future
+  enhancement) and communicate changes through onboarding notes.
+
+## Troubleshooting
+
+| Symptom | Resolution |
+| --- | --- |
+| CLI reports `Option --foo requires a value`. | Supply a value or drop the unknown option. Run `imme --help` for guidance. |
+| Persistent log not written. | Check filesystem permissions and ensure the parent directory is writable. The CLI reports the path when a failure occurs. |
+| Derived line missing from console. | Ensure the CLI is not run with `--dry-run` and that stdout is not redirected. |
+
+## Escalation Matrix
+
+1. **First responder**: On-call engineer rotates weekly; consult the shared
+   calendar for assignments.
+2. **Secondary**: Project maintainer responsible for the affected subsystem.
+3. **Tertiary**: Platform engineering lead for infrastructure issues.
+
+Escalations must include a link to the relevant log extracts and a summary of
+mitigations attempted.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,8 +10,17 @@ export default [
     files: ["**/*.js"],
     languageOptions: {
       ...languageOptions,
-      ecmaVersion: 2022,
+      ecmaVersion: "latest",
       sourceType: "module",
+      parserOptions: {
+        ...languageOptions?.parserOptions,
+        ecmaVersion: "latest",
+        sourceType: "module",
+        ecmaFeatures: {
+          ...languageOptions?.parserOptions?.ecmaFeatures,
+          importAssertions: true
+        }
+      },
       globals: {
         ...languageOptions?.globals,
         console: "readonly"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "imme",
       "version": "0.1.0",
       "license": "MIT",
+      "bin": {
+        "imme": "bin/imme.js"
+      },
       "devDependencies": {
         "@eslint/js": "^9.11.1",
         "eslint": "^9.11.1"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "description": "Imme project workspace",
   "type": "module",
+  "bin": {
+    "imme": "./bin/imme.js"
+  },
   "scripts": {
     "lint": "eslint .",
     "test": "node --test"

--- a/project-manager/task.md
+++ b/project-manager/task.md
@@ -6,10 +6,12 @@ This document tracks progress for the Imme project. Checkboxes reflect the curre
 
 - [x] Captured the initial backlog and selected a Node.js (ESM) stack to avoid implicit Python usage.
 - [x] Established the base project skeleton with linting, testing, and structured logging utilities.
+- [x] Defined the domain model and persistence requirements for managing Imme project data.
+- [x] Implemented persistent log storage that complements the console transport.
+- [x] Built a CLI interface that exercises the logger and future business logic end-to-end.
+- [x] Documented operational runbooks and developer onboarding notes.
 
 ## 🔄 In Progress / Backlog
 
-- [ ] Define the domain model and persistence requirements for managing Imme project data.
-- [ ] Implement persistent log storage that complements the console transport.
-- [ ] Build a CLI interface that exercises the logger and future business logic end-to-end.
-- [ ] Document operational runbooks and developer onboarding notes.
+- [ ] Expand the CLI to cover workspace configuration management.
+- [ ] Evaluate database options for persisting project and task entities.

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,1 @@
-export { StructuredLogger, createLogEntry } from "./logger.js";
+export { StructuredLogger, createLogEntry, createPersistentFileWriter } from "./logger.js";

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,3 +1,6 @@
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+
 const DEFAULT_METHOD = "NONE";
 const DEFAULT_DB_PHASE = "none";
 const ALLOWED_METHODS = new Set(["GET", "POST", "DELETE", "PUT", DEFAULT_METHOD]);
@@ -168,4 +171,53 @@ export class StructuredLogger {
 
     return entry;
   }
+}
+
+function ensureDirectoryExists(filePath) {
+  const directory = dirname(filePath);
+  if (!directory || directory === ".") {
+    return;
+  }
+
+  mkdirSync(directory, { recursive: true });
+}
+
+function normalizeLogValue(value) {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (value === undefined || value === null) {
+    return "";
+  }
+
+  return JSON.stringify(value);
+}
+
+export function createPersistentFileWriter({
+  filePath,
+  ensureDir = true,
+  mode = 0o600
+} = {}) {
+  if (typeof filePath !== "string" || filePath.trim().length === 0) {
+    throw new Error("filePath is required for persistent log writers");
+  }
+
+  if (ensureDir) {
+    ensureDirectoryExists(filePath);
+  }
+
+  const write = (value) => {
+    const serialized = normalizeLogValue(value);
+    appendFileSync(filePath, `${serialized}\n`, {
+      encoding: "utf8",
+      mode,
+      flag: "a"
+    });
+  };
+
+  return {
+    log: write,
+    write
+  };
 }

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -1,6 +1,13 @@
 import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync } from "node:fs";
 import test from "node:test";
-import { createLogEntry, StructuredLogger } from "../src/index.js";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createLogEntry,
+  StructuredLogger,
+  createPersistentFileWriter
+} from "../src/index.js";
 
 test("createLogEntry provides defaults and canonical derived line", () => {
   const { entry, derivedLine } = createLogEntry({
@@ -84,4 +91,26 @@ test("StructuredLogger.error accepts Error instances directly", () => {
   assert.equal(entry.db_phase, "none");
   assert.equal(persistent.length, 1);
   assert.equal(ephemeral.length, 1);
+});
+
+test("createPersistentFileWriter writes logs to disk", () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "imme-"));
+  const filePath = join(tempDir, "logs", "app.jsonl");
+  const persistentWriter = createPersistentFileWriter({ filePath });
+  const logger = new StructuredLogger({
+    persistentWriter,
+    ephemeralWriter: { log() {} },
+    baseContext: { filename: "disk-writer.js", systemSection: "persistence" }
+  });
+
+  logger.info({ message: "Disk write", method: "POST" });
+
+  const contents = readFileSync(filePath, "utf8").trim().split("\n");
+  assert.equal(contents.length, 1);
+
+  const record = JSON.parse(contents[0]);
+  assert.equal(record.message, "Disk write");
+  assert.equal(record.filename, "disk-writer.js");
+  assert.equal(record.system_section, "persistence");
+  assert.equal(record.method, "POST");
 });


### PR DESCRIPTION
## Summary
- document the project domain model along with runbook and onboarding guides
- add a persistent file writer for the structured logger and export it for consumers
- provide an `imme` CLI that writes JSONL logs, update metadata, and refresh the task tracker

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dec06705ac832bb43a0c8f52f70779