### PR TITLE
feat: expand CLI config management and npm scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules/
 .DS_Store
-.imme/
+.imme/logs*.jsonl

--- a/.imme/config.json
+++ b/.imme/config.json
@@ -1,0 +1,7 @@
+{
+  "workspace": {
+    "name": "Imme Workspace",
+    "environment": "development",
+    "lastUpdated": "2025-10-02T20:04:51.034Z"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@ Install dependencies:
 npm install
 ```
 
-Run linting and tests:
+Review the current workspace configuration and run quality gates:
 
 ```bash
+npm run start
+npm run build
 npm run lint
 npm test
 ```
@@ -43,6 +45,25 @@ imme log --message "hello" --filename cli.js
 Entries are appended to `.imme/logs.jsonl` by default. The CLI accepts
 additional context fields (`--system-section`, `--method`, `--db-phase`, etc.)
 that match the canonical log schema.
+
+## Workspace configuration management
+
+Use the `config` subcommands to manage workspace defaults:
+
+```bash
+# Create or refresh the configuration file
+imme config init --name "Imme Workspace"
+
+# Display the current configuration JSON
+imme config show
+
+# Update individual fields using dot-notation keys
+imme config set --key workspace.environment --value production
+```
+
+Configuration lives at `.imme/config.json` and should be committed whenever team
+defaults change. The CLI automatically stamps each update with an ISO-8601
+`lastUpdated` timestamp.
 
 Refer to `docs/runbook.md` for operational procedures and
 `docs/onboarding.md` for contributor guidelines.

--- a/bin/imme.js
+++ b/bin/imme.js
@@ -4,10 +4,14 @@ import { basename, join, resolve } from "node:path";
 import process from "node:process";
 import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
 
 import {
   StructuredLogger,
-  createPersistentFileWriter
+  createPersistentFileWriter,
+  ensureConfig,
+  loadConfig,
+  updateConfigValue
 } from "../src/index.js";
 
 const require = createRequire(import.meta.url);
@@ -21,6 +25,7 @@ function printUsage() {
   console.log("");
   console.log("Usage:");
   console.log(`  ${scriptName} log --message <text> [options]`);
+  console.log(`  ${scriptName} config <subcommand> [options]`);
   console.log("");
   console.log("Options:");
   console.log("  --message, -m         Log message to emit (required)");
@@ -33,8 +38,27 @@ function printUsage() {
   console.log("  --db-phase            Database phase context (pre, post)");
   console.log("  --log-file            Override persistent log file path");
   console.log("  --dry-run             Skip writing to persistent log storage");
-  console.log("  --help                Show this message");
+  console.log("  --help                Show this message (also works per-command)");
   console.log("  --version             Print version information");
+  console.log("");
+  console.log("Config subcommands:");
+  console.log("  init                  Create a workspace configuration file");
+  console.log("  show                  Display the current configuration");
+  console.log("  set --key <path> --value <value>   Update a configuration value");
+}
+
+function printConfigUsage() {
+  const scriptName = getScriptName();
+  console.log("Imme configuration management");
+  console.log("");
+  console.log("Usage:");
+  console.log(`  ${scriptName} config init [--force] [--name <text>] [--environment <text>]`);
+  console.log(`  ${scriptName} config show`);
+  console.log(`  ${scriptName} config set --key <path> --value <value>`);
+  console.log("");
+  console.log("Examples:");
+  console.log(`  ${scriptName} config init --name "Project Atlas"`);
+  console.log(`  ${scriptName} config set --key workspace.environment --value production`);
 }
 
 function getScriptName() {
@@ -43,26 +67,38 @@ function getScriptName() {
 }
 
 function parseArgs(rawArgs) {
-  const args = [...rawArgs];
-  let command = "log";
-  const options = {};
+  const filtered = [];
+  let helpRequested = false;
+  let versionRequested = false;
 
-  if (args.length > 0 && !args[0].startsWith("-")) {
-    command = args.shift();
-  }
-
-  while (args.length > 0) {
-    const token = args.shift();
+  for (const token of rawArgs) {
     if (token === "--help" || token === "-h") {
-      options.help = true;
+      helpRequested = true;
       continue;
     }
 
     if (token === "--version" || token === "-v") {
-      options.version = true;
+      versionRequested = true;
       continue;
     }
 
+    filtered.push(token);
+  }
+
+  let command = "log";
+  if (filtered.length > 0 && !filtered[0].startsWith("-")) {
+    command = filtered.shift();
+  }
+
+  return { command, args: filtered, helpRequested, versionRequested };
+}
+
+function parseLogOptions(tokens) {
+  const args = [...tokens];
+  const options = {};
+
+  while (args.length > 0) {
+    const token = args.shift();
     if (token === "--dry-run") {
       options.dryRun = true;
       continue;
@@ -100,7 +136,7 @@ function parseArgs(rawArgs) {
     throw new Error(`Unexpected argument: ${token}`);
   }
 
-  return { command, options };
+  return options;
 }
 
 function normalizeLevel(value = "info") {
@@ -128,41 +164,11 @@ function filterUndefinedEntries(entries) {
   return result;
 }
 
-function main() {
-  let parsed;
-  try {
-    parsed = parseArgs(process.argv.slice(2));
-  } catch (error) {
-    console.error(error.message);
-    printUsage();
-    process.exitCode = 1;
-    return;
-  }
-
-  const { command, options } = parsed;
-
-  if (options.help) {
-    printUsage();
-    return;
-  }
-
-  if (options.version) {
-    console.log(pkg.version);
-    return;
-  }
-
-  if (command !== "log") {
-    console.error(`Unknown command: ${command}`);
-    printUsage();
-    process.exitCode = 1;
-    return;
-  }
+function runLogCommand(args) {
+  const options = parseLogOptions(args);
 
   if (!options.message) {
-    console.error("--message is required for the log command");
-    printUsage();
-    process.exitCode = 1;
-    return;
+    throw new Error("--message is required for the log command");
   }
 
   const level = normalizeLevel(options.level);
@@ -170,13 +176,7 @@ function main() {
 
   let persistentWriter;
   if (!options.dryRun) {
-    try {
-      persistentWriter = createPersistentFileWriter({ filePath: logFilePath });
-    } catch (error) {
-      console.error(`Failed to create persistent log writer: ${error.message}`);
-      process.exitCode = 1;
-      return;
-    }
+    persistentWriter = createPersistentFileWriter({ filePath: logFilePath });
   } else {
     persistentWriter = {
       log() {},
@@ -220,4 +220,164 @@ function main() {
   }
 }
 
-main();
+function parseConfigOptions(tokens) {
+  const options = {};
+  const args = [...tokens];
+
+  while (args.length > 0) {
+    const token = args.shift();
+    if (token === "--force") {
+      options.force = true;
+      continue;
+    }
+
+    if (token === "--name") {
+      const value = args.shift();
+      if (value === undefined) {
+        throw new Error("Option --name requires a value");
+      }
+      options.name = value;
+      continue;
+    }
+
+    if (token === "--environment") {
+      const value = args.shift();
+      if (value === undefined) {
+        throw new Error("Option --environment requires a value");
+      }
+      options.environment = value;
+      continue;
+    }
+
+    if (token === "--key") {
+      const value = args.shift();
+      if (value === undefined) {
+        throw new Error("Option --key requires a value");
+      }
+      options.key = value;
+      continue;
+    }
+
+    if (token === "--value") {
+      const value = args.shift();
+      if (value === undefined) {
+        throw new Error("Option --value requires a value");
+      }
+      options.value = value;
+      continue;
+    }
+
+    throw new Error(`Unexpected argument: ${token}`);
+  }
+
+  return options;
+}
+
+function runConfigCommand(args) {
+  const tokens = [...args];
+  const subcommand = tokens.shift() ?? "show";
+
+  switch (subcommand) {
+    case "init": {
+      const options = parseConfigOptions(tokens);
+      const overrides = { workspace: {} };
+      if (options.name) {
+        overrides.workspace.name = options.name;
+      }
+      if (options.environment) {
+        overrides.workspace.environment = options.environment;
+      }
+
+      const { filePath, created } = ensureConfig({
+        overrides,
+        force: options.force
+      });
+
+      if (created) {
+        console.log(`Configuration created at ${filePath}`);
+      } else {
+        console.log(`Configuration already exists at ${filePath}`);
+      }
+      return;
+    }
+
+    case "show": {
+      const config = loadConfig();
+      console.log(JSON.stringify(config, null, 2));
+      return;
+    }
+
+    case "set": {
+      const options = parseConfigOptions(tokens);
+      if (!options.key) {
+        throw new Error("--key is required for config set");
+      }
+      if (options.value === undefined) {
+        throw new Error("--value is required for config set");
+      }
+
+      const { filePath } = updateConfigValue({ keyPath: options.key, value: options.value });
+      console.log(`Updated ${options.key} in ${filePath}`);
+      return;
+    }
+
+    default:
+      throw new Error(`Unknown config subcommand: ${subcommand}`);
+  }
+}
+
+function main(argv = process.argv.slice(2)) {
+  let parsed;
+  try {
+    parsed = parseArgs(argv);
+  } catch (error) {
+    console.error(error.message);
+    printUsage();
+    process.exitCode = 1;
+    return;
+  }
+
+  const { command, args, helpRequested, versionRequested } = parsed;
+
+  if (versionRequested) {
+    console.log(pkg.version);
+    return;
+  }
+
+  if (helpRequested) {
+    if (command === "config") {
+      printConfigUsage();
+      return;
+    }
+
+    printUsage();
+    return;
+  }
+
+  try {
+    switch (command) {
+      case "log":
+        runLogCommand(args);
+        break;
+      case "config":
+        runConfigCommand(args);
+        break;
+      default:
+        throw new Error(`Unknown command: ${command}`);
+    }
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}
+
+const isExecutedDirectly = (() => {
+  const modulePath = fileURLToPath(import.meta.url);
+  return process.argv[1] && resolve(process.argv[1]) === modulePath;
+})();
+
+if (isExecutedDirectly) {
+  main();
+}
+
+export { main, parseArgs, parseLogOptions, runLogCommand, runConfigCommand };

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -98,11 +98,28 @@ managed via operating runbooks.
    logic. UUIDs are mandated across entities to simplify replication and
    distributed workflows.
 
+## Database Options Evaluation
+
+Three candidate data stores were reviewed for managing structured entities once
+the project grows beyond Markdown-based tracking:
+
+| Option | Strengths | Considerations |
+| --- | --- | --- |
+| **SQLite** | Zero-dependency file-based engine, easy to embed within the CLI tooling, strong transactional guarantees. | Requires coordination when multiple contributors mutate the database concurrently; migrations must be versioned in Git. |
+| **PostgreSQL** | Mature relational system with advanced features (JSONB columns, row-level security) and scalable hosting options. | Adds operational overhead for local development; would require provisioning automation and secrets management. |
+| **Document store (LiteFS/SurrealDB)** | Flexible schema evolution, natural fit for nested task metadata, potential offline sync capabilities. | Ecosystem maturity varies; logging integration and query tooling would need additional vetting. |
+
+The recommended near-term path is to adopt SQLite for the first persistent data
+layer. It aligns with the repository's Git-centric workflow, supports
+structured schemas that mirror the existing Markdown representations, and can
+be upgraded to PostgreSQL once concurrency requirements warrant a client/server
+deployment.
+
 ## Future Considerations
 
 - Introduce an event-sourcing stream for CLI actions so that automation can
   rebuild state from log history.
-- Leverage SQLite for storing workspace, project, and task entities while
-  maintaining JSONL logs for append-only record keeping.
-- Expose persistence configuration through the CLI (`imme config`) once more
-  services depend on the data model.
+- Pilot SQLite-based storage using the evaluation above while maintaining JSONL
+  logs for append-only record keeping.
+- Extend the new `imme config` command so that persistence settings (database
+  path, rotation policies) are editable alongside log configuration.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -41,8 +41,12 @@ structured logging utilities delivered by the CLI.
   data. When sharing logs, strip secrets and adjust permissions explicitly.
 - **Backups**: Copy `.imme/logs.jsonl` into secure storage before destructive
   testing. The log format is append-only and can be replayed by future services.
-- **Configuration Changes**: Update the workspace configuration file (future
-  enhancement) and communicate changes through onboarding notes.
+- **Configuration Changes**: Manage the workspace configuration via the CLI:
+  - Initialize defaults: `imme config init --name "Imme Workspace"`
+  - Review current settings: `imme config show`
+  - Update individual fields: `imme config set --key workspace.environment --value production`
+  After each change, commit the updated `.imme/config.json` to share defaults
+  with the team and document the rationale in `project-manager/task.md`.
 
 ## Troubleshooting
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "imme": "./bin/imme.js"
   },
   "scripts": {
+    "start": "node ./bin/imme.js config show",
+    "build": "npm run lint && npm run test",
     "lint": "eslint .",
     "test": "node --test"
   },

--- a/project-manager/task.md
+++ b/project-manager/task.md
@@ -10,8 +10,10 @@ This document tracks progress for the Imme project. Checkboxes reflect the curre
 - [x] Implemented persistent log storage that complements the console transport.
 - [x] Built a CLI interface that exercises the logger and future business logic end-to-end.
 - [x] Documented operational runbooks and developer onboarding notes.
+- [x] Expanded the CLI with `config` subcommands to manage workspace defaults.
+- [x] Evaluated database options and recommended SQLite for the first persistent store.
 
 ## 🔄 In Progress / Backlog
 
-- [ ] Expand the CLI to cover workspace configuration management.
-- [ ] Evaluate database options for persisting project and task entities.
+- [ ] Implement SQLite-backed storage for projects and tasks using the evaluated design.
+- [ ] Automate configuration drift detection (notify when `.imme/config.json` diverges across clones).

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,175 @@
+import process from "node:process";
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+const DEFAULT_RELATIVE_CONFIG_PATH = join(".imme", "config.json");
+
+export const DEFAULT_CONFIG = Object.freeze({
+  workspace: {
+    name: "Imme Workspace",
+    environment: "development",
+    lastUpdated: null
+  }
+});
+
+function ensureDirectoryExists(filePath) {
+  const directory = dirname(filePath);
+  if (!directory || directory === ".") {
+    return;
+  }
+
+  mkdirSync(directory, { recursive: true });
+}
+
+function deepMerge(target, source) {
+  const merged = Array.isArray(target) ? [...target] : { ...target };
+
+  for (const [key, value] of Object.entries(source)) {
+    if (
+      value &&
+      typeof value === "object" &&
+      !Array.isArray(value) &&
+      typeof merged[key] === "object" &&
+      merged[key] !== null &&
+      !Array.isArray(merged[key])
+    ) {
+      merged[key] = deepMerge(merged[key], value);
+    } else {
+      merged[key] = value;
+    }
+  }
+
+  return merged;
+}
+
+export function resolveConfigPath({
+  cwd = process.cwd(),
+  relativePath = DEFAULT_RELATIVE_CONFIG_PATH
+} = {}) {
+  return resolve(cwd, relativePath);
+}
+
+export function loadConfig({
+  cwd = process.cwd(),
+  relativePath = DEFAULT_RELATIVE_CONFIG_PATH,
+  defaults = DEFAULT_CONFIG
+} = {}) {
+  const filePath = resolveConfigPath({ cwd, relativePath });
+  if (!existsSync(filePath)) {
+    return deepMerge({}, defaults);
+  }
+
+  const contents = readFileSync(filePath, "utf8");
+  if (contents.trim().length === 0) {
+    return deepMerge({}, defaults);
+  }
+
+  try {
+    const parsed = JSON.parse(contents);
+    return deepMerge(defaults, parsed);
+  } catch (error) {
+    throw new Error(`Invalid configuration JSON at ${filePath}: ${error.message}`);
+  }
+}
+
+export function writeConfig({
+  config,
+  cwd = process.cwd(),
+  relativePath = DEFAULT_RELATIVE_CONFIG_PATH
+} = {}) {
+  if (!config || typeof config !== "object") {
+    throw new Error("config must be an object");
+  }
+
+  const filePath = resolveConfigPath({ cwd, relativePath });
+  ensureDirectoryExists(filePath);
+
+  const serialized = `${JSON.stringify(config, null, 2)}\n`;
+  writeFileSync(filePath, serialized, { encoding: "utf8", mode: 0o600 });
+  return filePath;
+}
+
+function applyKey(config, keyPath, value) {
+  if (typeof keyPath !== "string" || keyPath.trim().length === 0) {
+    throw new Error("keyPath must be a non-empty string");
+  }
+
+  const segments = keyPath.split(".").map((segment) => segment.trim()).filter(Boolean);
+  if (segments.length === 0) {
+    throw new Error("keyPath must contain at least one segment");
+  }
+
+  let current = config;
+  for (let index = 0; index < segments.length - 1; index += 1) {
+    const segment = segments[index];
+    const existing = current[segment];
+    if (!existing || typeof existing !== "object" || Array.isArray(existing)) {
+      current[segment] = {};
+    }
+
+    current = current[segment];
+  }
+
+  const finalSegment = segments.at(-1);
+  current[finalSegment] = value;
+}
+
+function parseConfigValue(value) {
+  if (typeof value !== "string") {
+    return value;
+  }
+
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return "";
+  }
+
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return trimmed;
+  }
+}
+
+export function updateConfigValue({
+  keyPath,
+  value,
+  cwd = process.cwd(),
+  relativePath = DEFAULT_RELATIVE_CONFIG_PATH,
+  defaults = DEFAULT_CONFIG
+} = {}) {
+  const config = loadConfig({ cwd, relativePath, defaults });
+  const parsedValue = parseConfigValue(value);
+  applyKey(config, keyPath, parsedValue);
+  config.workspace = config.workspace ?? {};
+  config.workspace.lastUpdated = new Date().toISOString();
+  const filePath = writeConfig({ config, cwd, relativePath });
+  return { config, filePath };
+}
+
+export function ensureConfig({
+  cwd = process.cwd(),
+  relativePath = DEFAULT_RELATIVE_CONFIG_PATH,
+  defaults = DEFAULT_CONFIG,
+  force = false,
+  overrides = {}
+} = {}) {
+  const filePath = resolveConfigPath({ cwd, relativePath });
+  const exists = existsSync(filePath);
+  if (!force && exists) {
+    return { filePath, created: false };
+  }
+
+  let baseConfig = defaults;
+  if (force && exists) {
+    baseConfig = loadConfig({ cwd, relativePath, defaults });
+  }
+
+  const merged = deepMerge(baseConfig, overrides);
+  merged.workspace = merged.workspace ?? {};
+  merged.workspace.lastUpdated = new Date().toISOString();
+
+  writeConfig({ config: merged, cwd, relativePath });
+  return { filePath, created: true };
+}
+

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,13 @@
-export { StructuredLogger, createLogEntry, createPersistentFileWriter } from "./logger.js";
+export {
+  StructuredLogger,
+  createLogEntry,
+  createPersistentFileWriter
+} from "./logger.js";
+export {
+  DEFAULT_CONFIG,
+  ensureConfig,
+  loadConfig,
+  resolveConfigPath,
+  updateConfigValue,
+  writeConfig
+} from "./config.js";

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,0 +1,50 @@
+import process from "node:process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  parseArgs,
+  runConfigCommand
+} from "../bin/imme.js";
+
+function withTempCwd(callback) {
+  const originalCwd = process.cwd();
+  const cwd = mkdtempSync(join(tmpdir(), "imme-cli-"));
+
+  try {
+    process.chdir(cwd);
+    callback(cwd);
+  } finally {
+    process.chdir(originalCwd);
+    rmSync(cwd, { recursive: true, force: true });
+  }
+}
+
+test("parseArgs detects commands and flags", () => {
+  const result = parseArgs(["config", "init", "--force", "--name", "demo"]);
+  assert.equal(result.command, "config");
+  assert.deepEqual(result.args, ["init", "--force", "--name", "demo"]);
+  assert.equal(result.helpRequested, false);
+  assert.equal(result.versionRequested, false);
+
+  const helpResult = parseArgs(["--help"]);
+  assert.equal(helpResult.command, "log");
+  assert.equal(helpResult.helpRequested, true);
+});
+
+test("runConfigCommand init and set manage configuration", () => {
+  withTempCwd(() => {
+    runConfigCommand(["init", "--name", "Sample", "--environment", "test"]);
+    const configPath = join(process.cwd(), ".imme", "config.json");
+    const initial = JSON.parse(readFileSync(configPath, "utf8"));
+    assert.equal(initial.workspace.name, "Sample");
+    assert.equal(initial.workspace.environment, "test");
+
+    runConfigCommand(["set", "--key", "workspace.owner", "--value", "\"qa\""]);
+    const updated = JSON.parse(readFileSync(configPath, "utf8"));
+    assert.equal(updated.workspace.owner, "qa");
+  });
+});

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,0 +1,83 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  DEFAULT_CONFIG,
+  ensureConfig,
+  loadConfig,
+  resolveConfigPath,
+  updateConfigValue
+} from "../src/index.js";
+
+function createTempDir() {
+  return mkdtempSync(join(tmpdir(), "imme-config-"));
+}
+
+test("ensureConfig creates a configuration file with defaults", () => {
+  const cwd = createTempDir();
+
+  try {
+    const { filePath, created } = ensureConfig({ cwd });
+    assert.equal(created, true);
+    const contents = readFileSync(filePath, "utf8");
+    const parsed = JSON.parse(contents);
+    assert.equal(parsed.workspace.name, DEFAULT_CONFIG.workspace.name);
+    assert.equal(parsed.workspace.environment, DEFAULT_CONFIG.workspace.environment);
+    assert.ok(parsed.workspace.lastUpdated);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("ensureConfig respects overrides and force option", () => {
+  const cwd = createTempDir();
+
+  try {
+    const first = ensureConfig({ cwd, overrides: { workspace: { name: "First" } } });
+    assert.equal(first.created, true);
+
+    const second = ensureConfig({ cwd });
+    assert.equal(second.created, false);
+
+    const third = ensureConfig({ cwd, force: true, overrides: { workspace: { environment: "production" } } });
+    assert.equal(third.created, true);
+
+    const config = loadConfig({ cwd });
+    assert.equal(config.workspace.name, "First");
+    assert.equal(config.workspace.environment, "production");
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("updateConfigValue updates nested keys and maintains timestamp", () => {
+  const cwd = createTempDir();
+
+  try {
+    ensureConfig({ cwd });
+    const { filePath, config } = updateConfigValue({ cwd, keyPath: "workspace.region", value: "\"us-east\"" });
+    const persisted = JSON.parse(readFileSync(filePath, "utf8"));
+
+    assert.equal(config.workspace.region, "us-east");
+    assert.equal(persisted.workspace.region, "us-east");
+    assert.ok(persisted.workspace.lastUpdated);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("loadConfig throws on invalid JSON", () => {
+  const cwd = createTempDir();
+
+  try {
+    const filePath = resolveConfigPath({ cwd });
+    ensureConfig({ cwd });
+    writeFileSync(filePath, "not-json", "utf8");
+    assert.throws(() => loadConfig({ cwd }), /Invalid configuration JSON/);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add a configuration management module and wire new `config` subcommands into the CLI
- commit a shared `.imme/config.json` default and expose npm `start`/`build` scripts with updated docs
- extend documentation and the project task tracker with database option evaluation and maintenance procedures

## Testing
- npm run lint
- npm run test
- npm run build
- npm run start

------
https://chatgpt.com/codex/tasks/task_e_68ded99c0c38832b90a606d551d5fb27