### PR TITLE
Add SQLite workspace storage and dark mode dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 .DS_Store
 .imme/logs*.jsonl
+.imme/*.jsonl
+.imme/*.db

--- a/README.md
+++ b/README.md
@@ -59,11 +59,38 @@ imme config show
 
 # Update individual fields using dot-notation keys
 imme config set --key workspace.environment --value production
+
+# Update workspace metadata via guided flags
+imme config workspace set --environment staging --log-path ./artifacts/log.jsonl
 ```
 
 Configuration lives at `.imme/config.json` and should be committed whenever team
 defaults change. The CLI automatically stamps each update with an ISO-8601
-`lastUpdated` timestamp.
+`lastUpdated` timestamp. Run `imme config workspace show` to view resolved paths
+and SQLite connection details.
+
+## SQLite-backed storage
+
+Projects and tasks now persist to a SQLite database located at
+`.imme/imme.db` (configurable via the CLI). The `SQLiteStorage` class under
+`src/storage/sqlite.js` exposes CRUD helpers that mirror the domain model.
+
+- Migrations run automatically on startup and are versioned within the source
+  tree.
+- Tests use temporary databases to keep fixtures isolated.
+
+## Dark mode web UI
+
+Launch the workspace dashboard with:
+
+```bash
+npm run web
+```
+
+The server reads the shared SQLite database and exposes read-only APIs under
+`/api`. Visit `http://localhost:3000` to view workspace health, projects, and
+tasks. The interface follows the provided palette and the Laws of UX for a
+focused, high-contrast experience.
 
 Refer to `docs/runbook.md` for operational procedures and
 `docs/onboarding.md` for contributor guidelines.

--- a/bin/imme.js
+++ b/bin/imme.js
@@ -11,7 +11,10 @@ import {
   createPersistentFileWriter,
   ensureConfig,
   loadConfig,
-  updateConfigValue
+  loadWorkspaceSummary,
+  updateConfigValue,
+  updateWorkspaceConfig,
+  resolveConfigPath
 } from "../src/index.js";
 
 const require = createRequire(import.meta.url);
@@ -45,6 +48,7 @@ function printUsage() {
   console.log("  init                  Create a workspace configuration file");
   console.log("  show                  Display the current configuration");
   console.log("  set --key <path> --value <value>   Update a configuration value");
+  console.log("  workspace <action>    Manage workspace metadata (see --help)");
 }
 
 function printConfigUsage() {
@@ -55,10 +59,18 @@ function printConfigUsage() {
   console.log(`  ${scriptName} config init [--force] [--name <text>] [--environment <text>]`);
   console.log(`  ${scriptName} config show`);
   console.log(`  ${scriptName} config set --key <path> --value <value>`);
+  console.log(`  ${scriptName} config workspace show`);
+  console.log(
+    `  ${scriptName} config workspace set [--name <text>] [--environment <text>] [--log-path <path>] [--database-path <path>]`
+  );
+  console.log(`  ${scriptName} config workspace path`);
   console.log("");
   console.log("Examples:");
   console.log(`  ${scriptName} config init --name "Project Atlas"`);
   console.log(`  ${scriptName} config set --key workspace.environment --value production`);
+  console.log(
+    `  ${scriptName} config workspace set --environment staging --log-path ./artifacts/logs.jsonl`
+  );
 }
 
 function getScriptName() {
@@ -273,6 +285,54 @@ function parseConfigOptions(tokens) {
   return options;
 }
 
+function parseWorkspaceOptions(tokens) {
+  const options = {};
+  const args = [...tokens];
+
+  while (args.length > 0) {
+    const token = args.shift();
+
+    switch (token) {
+      case "--name": {
+        const value = args.shift();
+        if (value === undefined) {
+          throw new Error("Option --name requires a value");
+        }
+        options.name = value;
+        break;
+      }
+      case "--environment": {
+        const value = args.shift();
+        if (value === undefined) {
+          throw new Error("Option --environment requires a value");
+        }
+        options.environment = value;
+        break;
+      }
+      case "--log-path": {
+        const value = args.shift();
+        if (value === undefined) {
+          throw new Error("Option --log-path requires a value");
+        }
+        options.logPath = value;
+        break;
+      }
+      case "--database-path": {
+        const value = args.shift();
+        if (value === undefined) {
+          throw new Error("Option --database-path requires a value");
+        }
+        options.databasePath = value;
+        break;
+      }
+      default:
+        throw new Error(`Unexpected argument: ${token}`);
+    }
+  }
+
+  return options;
+}
+
 function runConfigCommand(args) {
   const tokens = [...args];
   const subcommand = tokens.shift() ?? "show";
@@ -319,6 +379,58 @@ function runConfigCommand(args) {
       const { filePath } = updateConfigValue({ keyPath: options.key, value: options.value });
       console.log(`Updated ${options.key} in ${filePath}`);
       return;
+    }
+
+    case "workspace": {
+      const workspaceCommand = tokens.shift() ?? "show";
+      switch (workspaceCommand) {
+        case "show": {
+          const { workspace } = loadWorkspaceSummary();
+          console.log(
+            JSON.stringify(
+              {
+                name: workspace.name,
+                environment: workspace.environment,
+                logPath: workspace.logPath,
+                databasePath: workspace.databasePath,
+                database: workspace.database,
+                lastUpdated: workspace.lastUpdated
+              },
+              null,
+              2
+            )
+          );
+          return;
+        }
+        case "set": {
+          const options = parseWorkspaceOptions(tokens);
+          if (Object.keys(options).length === 0) {
+            throw new Error("Provide at least one workspace field to update");
+          }
+          const { filePath } = updateWorkspaceConfig({ updates: options });
+          console.log(`Workspace configuration updated in ${filePath}`);
+          return;
+        }
+        case "path": {
+          const { workspace, config } = loadWorkspaceSummary();
+          const configPath = resolveConfigPath();
+          console.log(
+            JSON.stringify(
+              {
+                configPath,
+                logPath: workspace.logPath,
+                databasePath: workspace.databasePath,
+                lastUpdated: workspace.lastUpdated ?? config.workspace?.lastUpdated ?? null
+              },
+              null,
+              2
+            )
+          );
+          return;
+        }
+        default:
+          throw new Error(`Unknown workspace subcommand: ${workspaceCommand}`);
+      }
     }
 
     default:

--- a/docs/database-evaluation.md
+++ b/docs/database-evaluation.md
@@ -1,0 +1,33 @@
+# Database Options Evaluation
+
+This analysis validates our choice of SQLite for persisting Imme projects and tasks while
+tracking the trade-offs across the primary candidates.
+
+## Decision Summary
+
+- **Recommended store:** SQLite (file-backed, embedded).
+- **Rationale:** Aligns with the repository-first workflow, requires zero services to
+  operate, and unlocks transactional guarantees missing from Markdown-based tracking.
+- **Fallback options:** PostgreSQL for future multi-user concurrency; document stores for
+  schemaless experimentation.
+
+## Option Comparison
+
+| Option | Advantages | Considerations |
+| --- | --- | --- |
+| SQLite | Embedded, transactional, ships with robust tooling (`sqlite3`, `.dump`). | Requires migration discipline, limited concurrent writers. |
+| PostgreSQL | Mature ecosystem, rich SQL surface, first-class migrations. | Needs operational footprint (container, secrets, provisioning). |
+| Document store (LiteFS / SurrealDB) | Flexible schema evolution, natural for nested task notes. | Requires new operational playbooks, less proven analytics tooling. |
+
+## Adoption Plan
+
+1. **Embed SQLite in the CLI.** Use the `better-sqlite3` driver to create a synchronous
+   API that matches the current CLI execution model.
+2. **Version schema migrations.** Store DDL statements in source control and append an
+   entry to `schema_migrations` as part of each deployment.
+3. **Align configuration.** Persist the database file within `.imme/` so contributors
+   can opt into sharing state via Git, mirroring the existing log strategy.
+4. **Document fallbacks.** Outline when PostgreSQL (high concurrency) or a document
+   store (rapid schema iteration) becomes the right tool.
+
+This evaluation is a living reference; update it as requirements evolve.

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -122,4 +122,20 @@ deployment.
 - Pilot SQLite-based storage using the evaluation above while maintaining JSONL
   logs for append-only record keeping.
 - Extend the new `imme config` command so that persistence settings (database
-  path, rotation policies) are editable alongside log configuration.
+  path, rotation policies) are editable alongside log configuration. The
+  `workspace` subcommand now provides a guided surface for changing the log
+  destination and SQLite database location.
+
+## SQLite Storage Implementation
+
+- **Driver:** [`better-sqlite3`](https://github.com/WiseLibs/better-sqlite3)
+  for synchronous access inside the CLI and web server.
+- **Schema:** `projects` and `tasks` tables mirror the Markdown domain model
+  with UUID primary keys, ISO-8601 timestamps, and enum-backed status columns.
+- **Migrations:** DDL statements are versioned in code and tracked with a
+  `schema_migrations` table to maintain forward-only evolution.
+- **Integration points:**
+  - CLI commands read configuration from `.imme/config.json` and update
+    workspace metadata using structured setters.
+  - The web UI consumes a read-only API served by `src/web/server.js`, backed
+    by the shared SQLite storage layer.

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -1,0 +1,37 @@
+# Web UI Design Notes
+
+The Imme web control center embraces dark mode with the palette provided by the team:
+
+- Background: `#2F212F`
+- Primary surface: `#565A7B`
+- Muted text: `#8C8789`
+- Highlight text: `#EAF0EC`
+
+## UX Principles Applied
+
+- **Aesthetic-Usability Effect:** A polished, high-contrast gradient and layered cards
+  increase perceived usability while maintaining accessible color ratios.
+- **Hick's Law:** Every panel focuses on a single decision—select a project, review its
+  tasks—limiting the number of simultaneous choices.
+- **Jakob's Law:** Familiar list-card patterns and pill statuses mirror modern project
+  tools, reducing the cognitive load for new contributors.
+- **Law of Proximity:** Grouped summary data uses CSS grids to establish clear visual
+  relationships between workspace attributes.
+- **Peak-End Rule:** The footer reinforces the UX principles and mission, ending the
+  experience on a consistent note.
+
+## Interaction Model
+
+1. **Refresh button** pulls configuration and database state in one click, with focus
+   rings sized using Fitts's Law for fast acquisition.
+2. **Project cards** act as large hit targets; active cards receive subtle glows to
+   signal state changes.
+3. **Tasks panel** uses polite live regions so screen readers announce updates when a
+   project is selected.
+
+## Accessibility Checklist
+
+- Semantic headings (`h1`/`h2`) guide assistive navigation.
+- High-contrast pill badges distinguish task statuses.
+- Reduced motion: only lightweight hover transitions are used; no flashing.
+- Keyboard support: project cards are keyboard-activatable via focus-within styling.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "imme",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "better-sqlite3": "^9.4.3"
+      },
       "bin": {
         "imme": "bin/imme.js"
       },
@@ -293,6 +296,57 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-9.6.0.tgz",
+      "integrity": "sha512-yR5HATnqeYNVnkaUTf4bOP2dJSnyhP4puJN/QPRyx4YkBEEUxib422n2XzPqDEHjQQqazoYoADdAm5vE15+dAQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -302,6 +356,30 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/callsites": {
@@ -330,6 +408,12 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -391,12 +475,54 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.1.tgz",
+      "integrity": "sha512-ecqj/sy1jcK1uWrwpR67UhYrIFQ+5WlGxth34WquCbamhFA6hkkwiu37o6J5xCHdo1oixJRfVRw+ywV+Hq/0Aw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -566,6 +692,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -599,6 +734,12 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -638,6 +779,18 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -673,6 +826,26 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -710,6 +883,18 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -822,6 +1007,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -835,11 +1032,32 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "license": "MIT"
     },
     "node_modules/natural-compare": {
@@ -848,6 +1066,27 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.77.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.77.0.tgz",
+      "integrity": "sha512-DSmt0OEcLoK4i3NuscSbGjOf3bqiDEutejqENSplMSFA/gmB8mkED9G4pKWnPl7MDU4rSHebKPHeitpDfyH0cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -932,6 +1171,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -940,6 +1205,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -952,6 +1227,44 @@
         "node": ">=6"
       }
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -960,6 +1273,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/shebang-command": {
@@ -983,6 +1328,60 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/strip-json-comments": {
@@ -1011,6 +1410,46 @@
         "node": ">=8"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -1033,6 +1472,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -1059,6 +1504,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "start": "node ./bin/imme.js config show",
     "build": "npm run lint && npm run test",
     "lint": "eslint .",
-    "test": "node --test"
+    "test": "node --test",
+    "web": "node ./src/web/server.js"
   },
   "keywords": [],
   "author": "",
@@ -18,5 +19,8 @@
   "devDependencies": {
     "@eslint/js": "^9.11.1",
     "eslint": "^9.11.1"
+  },
+  "dependencies": {
+    "better-sqlite3": "^9.4.3"
   }
 }

--- a/project-manager/task.md
+++ b/project-manager/task.md
@@ -12,8 +12,12 @@ This document tracks progress for the Imme project. Checkboxes reflect the curre
 - [x] Documented operational runbooks and developer onboarding notes.
 - [x] Expanded the CLI with `config` subcommands to manage workspace defaults.
 - [x] Evaluated database options and recommended SQLite for the first persistent store.
+- [x] Expanded the CLI workspace management surface (`config workspace` flows).
+- [x] Implemented SQLite-backed persistence for projects and tasks.
+- [x] Delivered a dark-mode web UI for monitoring workspace health.
+- [x] Documented trade-offs between SQLite, PostgreSQL, and document stores.
 
 ## 🔄 In Progress / Backlog
 
-- [ ] Implement SQLite-backed storage for projects and tasks using the evaluated design.
 - [ ] Automate configuration drift detection (notify when `.imme/config.json` diverges across clones).
+- [ ] Expand the web API to support creating and updating projects from the UI.

--- a/src/config.js
+++ b/src/config.js
@@ -1,13 +1,25 @@
 import process from "node:process";
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { dirname, isAbsolute, join, resolve } from "node:path";
 
 const DEFAULT_RELATIVE_CONFIG_PATH = join(".imme", "config.json");
+const DEFAULT_RELATIVE_LOG_PATH = join(".imme", "logs.jsonl");
+const DEFAULT_RELATIVE_DATABASE_PATH = join(".imme", "imme.db");
 
 export const DEFAULT_CONFIG = Object.freeze({
   workspace: {
     name: "Imme Workspace",
     environment: "development",
+    paths: {
+      log: DEFAULT_RELATIVE_LOG_PATH,
+      database: DEFAULT_RELATIVE_DATABASE_PATH
+    },
+    database: {
+      client: "sqlite",
+      options: {
+        filename: DEFAULT_RELATIVE_DATABASE_PATH
+      }
+    },
     lastUpdated: null
   }
 });
@@ -143,6 +155,110 @@ export function updateConfigValue({
   applyKey(config, keyPath, parsedValue);
   config.workspace = config.workspace ?? {};
   config.workspace.lastUpdated = new Date().toISOString();
+  const filePath = writeConfig({ config, cwd, relativePath });
+  return { config, filePath };
+}
+
+function resolvePathWithinWorkspace(pathValue, cwd = process.cwd()) {
+  if (typeof pathValue !== "string" || pathValue.trim().length === 0) {
+    return null;
+  }
+
+  if (isAbsolute(pathValue)) {
+    return pathValue;
+  }
+
+  return resolve(cwd, pathValue);
+}
+
+function cloneWorkspaceConfig(workspace = {}) {
+  const cloned = { ...workspace };
+  cloned.paths = { ...workspace.paths };
+  cloned.database = { ...workspace.database };
+  if (workspace.database?.options) {
+    cloned.database.options = { ...workspace.database.options };
+  }
+  return cloned;
+}
+
+export function loadWorkspaceSummary({
+  cwd = process.cwd(),
+  relativePath = DEFAULT_RELATIVE_CONFIG_PATH,
+  defaults = DEFAULT_CONFIG
+} = {}) {
+  const config = loadConfig({ cwd, relativePath, defaults });
+  const workspace = cloneWorkspaceConfig(config.workspace ?? {});
+  const logPath = resolvePathWithinWorkspace(
+    workspace.paths?.log ?? DEFAULT_RELATIVE_LOG_PATH,
+    cwd
+  );
+  const databasePath = resolvePathWithinWorkspace(
+    workspace.paths?.database ?? DEFAULT_RELATIVE_DATABASE_PATH,
+    cwd
+  );
+
+  return {
+    config,
+    workspace: {
+      name: workspace.name ?? defaults.workspace.name,
+      environment: workspace.environment ?? defaults.workspace.environment,
+      logPath,
+      databasePath,
+      database: {
+        client: workspace.database?.client ?? defaults.workspace.database.client,
+        options: {
+          filename:
+            workspace.database?.options?.filename ?? DEFAULT_RELATIVE_DATABASE_PATH
+        }
+      },
+      lastUpdated: workspace.lastUpdated ?? null
+    }
+  };
+}
+
+export function updateWorkspaceConfig({
+  updates = {},
+  cwd = process.cwd(),
+  relativePath = DEFAULT_RELATIVE_CONFIG_PATH,
+  defaults = DEFAULT_CONFIG
+} = {}) {
+  if (!updates || typeof updates !== "object") {
+    throw new Error("updates must be an object");
+  }
+
+  const config = loadConfig({ cwd, relativePath, defaults });
+  const workspace = cloneWorkspaceConfig(config.workspace ?? {});
+
+  if (Object.hasOwn(updates, "name")) {
+    workspace.name = updates.name;
+  }
+
+  if (Object.hasOwn(updates, "environment")) {
+    workspace.environment = updates.environment;
+  }
+
+  if (Object.hasOwn(updates, "logPath")) {
+    const logPath = updates.logPath;
+    workspace.paths = workspace.paths ?? {};
+    workspace.paths.log = logPath;
+  }
+
+  if (Object.hasOwn(updates, "databasePath")) {
+    const databasePath = updates.databasePath;
+    workspace.paths = workspace.paths ?? {};
+    workspace.paths.database = databasePath;
+    workspace.database = workspace.database ?? {};
+    workspace.database.options = workspace.database.options ?? {};
+    workspace.database.options.filename = databasePath;
+  }
+
+  if (Object.hasOwn(updates, "database")) {
+    workspace.database = deepMerge(workspace.database ?? {}, updates.database);
+  }
+
+  workspace.lastUpdated = new Date().toISOString();
+  config.workspace = workspace;
+
   const filePath = writeConfig({ config, cwd, relativePath });
   return { config, filePath };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,9 @@ export {
   ensureConfig,
   loadConfig,
   resolveConfigPath,
+  loadWorkspaceSummary,
   updateConfigValue,
+  updateWorkspaceConfig,
   writeConfig
 } from "./config.js";
+export { SQLiteStorage, createSQLiteStorage } from "./storage/sqlite.js";

--- a/src/storage/sqlite.js
+++ b/src/storage/sqlite.js
@@ -1,0 +1,450 @@
+import { randomUUID } from "node:crypto";
+import { mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import process from "node:process";
+
+import Database from "better-sqlite3";
+
+import { StructuredLogger } from "../logger.js";
+
+const PROJECT_STATUSES = new Set(["proposed", "active", "complete"]);
+const TASK_STATUSES = new Set(["todo", "in_progress", "blocked", "done"]);
+
+const MIGRATIONS = [
+  {
+    version: 1,
+    statements: [
+      `CREATE TABLE IF NOT EXISTS schema_migrations (
+        version INTEGER PRIMARY KEY,
+        applied_at TEXT NOT NULL
+      )`,
+      `CREATE TABLE IF NOT EXISTS projects (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        description TEXT DEFAULT '',
+        status TEXT NOT NULL DEFAULT 'proposed' CHECK(status IN ('proposed','active','complete')),
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      )`,
+      `CREATE TABLE IF NOT EXISTS tasks (
+        id TEXT PRIMARY KEY,
+        project_id TEXT NOT NULL,
+        title TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'todo' CHECK(status IN ('todo','in_progress','blocked','done')),
+        assignees TEXT NOT NULL DEFAULT '[]',
+        notes TEXT DEFAULT '',
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        FOREIGN KEY(project_id) REFERENCES projects(id) ON DELETE CASCADE
+      )`,
+      `CREATE INDEX IF NOT EXISTS idx_tasks_project_id ON tasks(project_id)`
+    ]
+  }
+];
+
+function ensureDirectoryExists(filePath) {
+  const directory = dirname(filePath);
+  if (!directory || directory === ".") {
+    return;
+  }
+  mkdirSync(directory, { recursive: true });
+}
+
+function now() {
+  return new Date().toISOString();
+}
+
+function serializeAssignees(assignees = []) {
+  if (!Array.isArray(assignees)) {
+    throw new Error("assignees must be an array");
+  }
+  return JSON.stringify(assignees);
+}
+
+function deserializeAssignees(payload) {
+  if (!payload) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(payload);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function normalizeStatus(status, allowed) {
+  if (typeof status !== "string") {
+    return null;
+  }
+
+  const normalized = status.trim().toLowerCase();
+  return allowed.has(normalized) ? normalized : null;
+}
+
+export class SQLiteStorage {
+  constructor({ filePath, logger, name = "sqlite-storage" } = {}) {
+    if (!filePath) {
+      throw new Error("filePath is required to initialize SQLiteStorage");
+    }
+
+    const resolvedPath = resolve(process.cwd(), filePath);
+    ensureDirectoryExists(resolvedPath);
+
+    this.filePath = resolvedPath;
+    this.logger = logger ??
+      new StructuredLogger({
+        baseContext: { filename: "storage/sqlite.js", classname: "SQLiteStorage" }
+      });
+    this.name = name;
+
+    this.#db = new Database(this.filePath);
+    this.#db.pragma("journal_mode = WAL");
+    this.#db.pragma("foreign_keys = ON");
+
+    this.#log("INFO", {
+      functionName: "constructor",
+      message: `Opening SQLite database at ${this.filePath}`
+    });
+
+    this.#runMigrations();
+    this.#prepareStatements();
+  }
+
+  close() {
+    this.#log("INFO", {
+      functionName: "close",
+      message: `Closing SQLite database at ${this.filePath}`
+    });
+    this.#db.close();
+  }
+
+  get database() {
+    return this.#db;
+  }
+
+  createProject({ id = randomUUID(), name, description = "", status = "proposed" } = {}) {
+    if (!name) {
+      throw new Error("Project name is required");
+    }
+
+    const normalizedStatus = normalizeStatus(status, PROJECT_STATUSES) ?? "proposed";
+    const timestamp = now();
+
+    const payload = {
+      id,
+      name,
+      description,
+      status: normalizedStatus,
+      createdAt: timestamp,
+      updatedAt: timestamp
+    };
+
+    const insert = this.#statements.insertProject;
+    insert.run(payload);
+
+    this.#log("INFO", {
+      functionName: "createProject",
+      message: `Created project ${id}`,
+      systemSection: "projects"
+    });
+
+    return payload;
+  }
+
+  listProjects() {
+    const rows = this.#statements.listProjects.all();
+    return rows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      description: row.description,
+      status: row.status,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at
+    }));
+  }
+
+  getProjectById(id) {
+    const row = this.#statements.getProjectById.get(id);
+    if (!row) {
+      return null;
+    }
+
+    return {
+      id: row.id,
+      name: row.name,
+      description: row.description,
+      status: row.status,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at
+    };
+  }
+
+  updateProject({ id, name, description, status }) {
+    if (!id) {
+      throw new Error("Project id is required");
+    }
+
+    const existing = this.getProjectById(id);
+    if (!existing) {
+      throw new Error(`Project ${id} does not exist`);
+    }
+
+    const updated = {
+      name: name ?? existing.name,
+      description: description ?? existing.description,
+      status: normalizeStatus(status ?? existing.status, PROJECT_STATUSES) ?? existing.status,
+      updatedAt: now(),
+      id
+    };
+
+    this.#statements.updateProject.run(updated);
+
+    this.#log("INFO", {
+      functionName: "updateProject",
+      message: `Updated project ${id}`,
+      systemSection: "projects"
+    });
+
+    return this.getProjectById(id);
+  }
+
+  createTask({
+    id = randomUUID(),
+    projectId,
+    title,
+    status = "todo",
+    assignees = [],
+    notes = ""
+  } = {}) {
+    if (!projectId) {
+      throw new Error("projectId is required");
+    }
+    if (!title) {
+      throw new Error("Task title is required");
+    }
+
+    const project = this.getProjectById(projectId);
+    if (!project) {
+      throw new Error(`Project ${projectId} does not exist`);
+    }
+
+    const normalizedStatus = normalizeStatus(status, TASK_STATUSES) ?? "todo";
+    const timestamp = now();
+
+    const payload = {
+      id,
+      projectId,
+      title,
+      status: normalizedStatus,
+      assignees: serializeAssignees(assignees),
+      notes,
+      createdAt: timestamp,
+      updatedAt: timestamp
+    };
+
+    this.#statements.insertTask.run(payload);
+
+    this.#log("INFO", {
+      functionName: "createTask",
+      message: `Created task ${id} for project ${projectId}`,
+      systemSection: "tasks"
+    });
+
+    return this.getTaskById(id);
+  }
+
+  getTaskById(id) {
+    const row = this.#statements.getTaskById.get(id);
+    if (!row) {
+      return null;
+    }
+
+    return {
+      id: row.id,
+      projectId: row.project_id,
+      title: row.title,
+      status: row.status,
+      assignees: deserializeAssignees(row.assignees),
+      notes: row.notes,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at
+    };
+  }
+
+  listTasksByProject(projectId) {
+    const rows = this.#statements.listTasksByProject.all(projectId);
+    return rows.map((row) => ({
+      id: row.id,
+      projectId: row.project_id,
+      title: row.title,
+      status: row.status,
+      assignees: deserializeAssignees(row.assignees),
+      notes: row.notes,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at
+    }));
+  }
+
+  updateTask({ id, title, status, assignees, notes }) {
+    if (!id) {
+      throw new Error("Task id is required");
+    }
+
+    const existing = this.getTaskById(id);
+    if (!existing) {
+      throw new Error(`Task ${id} does not exist`);
+    }
+
+    const payload = {
+      title: title ?? existing.title,
+      status: normalizeStatus(status ?? existing.status, TASK_STATUSES) ?? existing.status,
+      assignees: serializeAssignees(assignees ?? existing.assignees),
+      notes: notes ?? existing.notes,
+      updatedAt: now(),
+      id
+    };
+
+    this.#statements.updateTask.run(payload);
+
+    this.#log("INFO", {
+      functionName: "updateTask",
+      message: `Updated task ${id}`,
+      systemSection: "tasks"
+    });
+
+    return this.getTaskById(id);
+  }
+
+  deleteTask(id) {
+    if (!id) {
+      throw new Error("Task id is required");
+    }
+
+    this.#statements.deleteTask.run(id);
+    this.#log("INFO", {
+      functionName: "deleteTask",
+      message: `Deleted task ${id}`,
+      systemSection: "tasks",
+      dbPhase: "post"
+    });
+  }
+
+  #prepareStatements() {
+    this.#statements = {
+      insertProject: this.#db.prepare(`
+        INSERT INTO projects (id, name, description, status, created_at, updated_at)
+        VALUES (@id, @name, @description, @status, @createdAt, @updatedAt)
+      `),
+      listProjects: this.#db.prepare(`
+        SELECT id, name, description, status, created_at, updated_at
+        FROM projects
+        ORDER BY created_at DESC
+      `),
+      getProjectById: this.#db.prepare(`
+        SELECT id, name, description, status, created_at, updated_at
+        FROM projects
+        WHERE id = ?
+      `),
+      updateProject: this.#db.prepare(`
+        UPDATE projects
+        SET name = @name,
+            description = @description,
+            status = @status,
+            updated_at = @updatedAt
+        WHERE id = @id
+      `),
+      insertTask: this.#db.prepare(`
+        INSERT INTO tasks (id, project_id, title, status, assignees, notes, created_at, updated_at)
+        VALUES (@id, @projectId, @title, @status, @assignees, @notes, @createdAt, @updatedAt)
+      `),
+      getTaskById: this.#db.prepare(`
+        SELECT id, project_id, title, status, assignees, notes, created_at, updated_at
+        FROM tasks
+        WHERE id = ?
+      `),
+      listTasksByProject: this.#db.prepare(`
+        SELECT id, project_id, title, status, assignees, notes, created_at, updated_at
+        FROM tasks
+        WHERE project_id = ?
+        ORDER BY created_at DESC
+      `),
+      updateTask: this.#db.prepare(`
+        UPDATE tasks
+        SET title = @title,
+            status = @status,
+            assignees = @assignees,
+            notes = @notes,
+            updated_at = @updatedAt
+        WHERE id = @id
+      `),
+      deleteTask: this.#db.prepare(`
+        DELETE FROM tasks WHERE id = ?
+      `)
+    };
+  }
+
+  #runMigrations() {
+    this.#db.exec(`CREATE TABLE IF NOT EXISTS schema_migrations (
+      version INTEGER PRIMARY KEY,
+      applied_at TEXT NOT NULL
+    )`);
+
+    const appliedRows = this.#db
+      .prepare("SELECT version FROM schema_migrations ORDER BY version ASC")
+      .all();
+    const applied = new Set(appliedRows.map((row) => row.version));
+
+    for (const migration of MIGRATIONS) {
+      if (applied.has(migration.version)) {
+        continue;
+      }
+
+      this.#log("INFO", {
+        functionName: "#runMigrations",
+        message: `Applying migration ${migration.version}`,
+        systemSection: "migrations",
+        dbPhase: "pre"
+      });
+
+      const applyMigration = this.#db.transaction(() => {
+        for (const statement of migration.statements) {
+          this.#db.prepare(statement).run();
+        }
+        this.#db
+          .prepare("INSERT INTO schema_migrations (version, applied_at) VALUES (?, ?)")
+          .run(migration.version, now());
+      });
+
+      applyMigration();
+
+      this.#log("INFO", {
+        functionName: "#runMigrations",
+        message: `Migration ${migration.version} applied`,
+        systemSection: "migrations",
+        dbPhase: "post"
+      });
+    }
+  }
+
+  #log(level, context) {
+    if (!this.logger || typeof this.logger[level.toLowerCase()] !== "function") {
+      return;
+    }
+
+    const base = {
+      filename: "storage/sqlite.js",
+      classname: "SQLiteStorage",
+      method: "NONE"
+    };
+    this.logger[level.toLowerCase()]({ ...base, ...context });
+  }
+
+  #db;
+  #statements;
+}
+
+export function createSQLiteStorage(options = {}) {
+  return new SQLiteStorage(options);
+}

--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -1,0 +1,190 @@
+/* eslint-env browser */
+/* global document, fetch */
+
+const state = {
+  selectedProjectId: null,
+  projects: [],
+  tasks: []
+};
+
+const fields = {
+  name: document.querySelector('[data-field="workspace-name"]'),
+  environment: document.querySelector('[data-field="workspace-environment"]'),
+  logPath: document.querySelector('[data-field="workspace-log"]'),
+  database: document.querySelector('[data-field="workspace-database"]'),
+  updated: document.querySelector('[data-field="workspace-updated"]'),
+  tasksContext: document.querySelector('[data-field="tasks-context"]')
+};
+
+const elements = {
+  refresh: document.querySelector('.refresh-button'),
+  projectList: document.querySelector('.project-list'),
+  taskList: document.querySelector('.task-list')
+};
+
+async function fetchJson(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Request failed with status ${response.status}`);
+  }
+  return response.json();
+}
+
+function formatDate(value) {
+  if (!value) {
+    return '—';
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.valueOf())) {
+    return value;
+  }
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short'
+  }).format(date);
+}
+
+function renderWorkspaceSummary(workspace) {
+  fields.name.textContent = workspace.name;
+  fields.environment.textContent = workspace.environment;
+  fields.logPath.textContent = workspace.logPath ?? '—';
+  fields.database.textContent = `${workspace.database.client} → ${workspace.databasePath}`;
+  fields.updated.textContent = formatDate(workspace.lastUpdated);
+}
+
+function renderProjects(projects) {
+  elements.projectList.innerHTML = '';
+  if (projects.length === 0) {
+    const empty = document.createElement('li');
+    empty.className = 'empty-state';
+    empty.textContent = 'No projects yet. Create one via the CLI to get started.';
+    elements.projectList.appendChild(empty);
+    return;
+  }
+
+  for (const project of projects) {
+    const item = document.createElement('li');
+    item.className = 'project-card';
+    if (project.id === state.selectedProjectId) {
+      item.classList.add('active');
+    }
+
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.setAttribute('data-project-id', project.id);
+    button.addEventListener('click', () => selectProject(project.id));
+
+    const heading = document.createElement('h3');
+    heading.textContent = project.name;
+    const description = document.createElement('p');
+    description.textContent = project.description || 'No description yet.';
+
+    const status = document.createElement('span');
+    status.className = 'status-pill';
+    status.dataset.status = project.status;
+    status.textContent = project.status.replace(/_/g, ' ');
+
+    button.append(heading, description, status);
+    item.append(button);
+    elements.projectList.appendChild(item);
+  }
+}
+
+function renderTasks(tasks) {
+  elements.taskList.innerHTML = '';
+  if (!state.selectedProjectId) {
+    fields.tasksContext.textContent = 'Choose a project to load its tasks.';
+    return;
+  }
+
+  if (tasks.length === 0) {
+    fields.tasksContext.textContent = 'No tasks yet — time to plan the next move.';
+    const empty = document.createElement('li');
+    empty.className = 'empty-state';
+    empty.textContent = 'Tasks will appear here once they are added to the project.';
+    elements.taskList.appendChild(empty);
+    return;
+  }
+
+  fields.tasksContext.textContent = `${tasks.length} task${tasks.length === 1 ? '' : 's'} linked to this project.`;
+
+  for (const task of tasks) {
+    const item = document.createElement('li');
+    item.className = 'task-card';
+
+    const heading = document.createElement('h3');
+    heading.textContent = task.title;
+
+    const status = document.createElement('span');
+    status.className = 'status-pill';
+    status.dataset.status = task.status;
+    status.textContent = task.status.replace(/_/g, ' ');
+
+    const notes = document.createElement('p');
+    notes.textContent = task.notes || 'No notes yet.';
+
+    item.append(heading, status);
+
+    if (task.assignees?.length) {
+      const assignees = document.createElement('p');
+      assignees.textContent = `Assigned to: ${task.assignees.join(', ')}`;
+      item.append(assignees);
+    }
+
+    item.append(notes);
+    elements.taskList.appendChild(item);
+  }
+}
+
+async function loadWorkspace() {
+  const { workspace } = await fetchJson('/api/workspace');
+  renderWorkspaceSummary(workspace);
+}
+
+async function loadProjects() {
+  const { projects } = await fetchJson('/api/projects');
+  state.projects = projects;
+  if (state.selectedProjectId && !projects.some((project) => project.id === state.selectedProjectId)) {
+    state.selectedProjectId = null;
+  }
+  renderProjects(projects);
+  if (state.selectedProjectId) {
+    await loadTasks(state.selectedProjectId);
+  } else {
+    renderTasks([]);
+  }
+}
+
+async function loadTasks(projectId) {
+  const { tasks } = await fetchJson(`/api/projects/${projectId}/tasks`);
+  state.tasks = tasks;
+  renderTasks(tasks);
+}
+
+async function selectProject(projectId) {
+  state.selectedProjectId = projectId;
+  renderProjects(state.projects);
+  await loadTasks(projectId);
+}
+
+async function refresh() {
+  try {
+    elements.refresh.setAttribute('aria-busy', 'true');
+    elements.refresh.disabled = true;
+    await Promise.all([loadWorkspace(), loadProjects()]);
+  } catch (error) {
+    console.error('Failed to refresh workspace:', error);
+    fields.tasksContext.textContent = 'Something went wrong. Check the logs and try again.';
+  } finally {
+    elements.refresh.disabled = false;
+    elements.refresh.removeAttribute('aria-busy');
+  }
+}
+
+elements.refresh.addEventListener('click', () => {
+  refresh();
+});
+
+document.addEventListener('DOMContentLoaded', () => {
+  refresh();
+});

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Imme Workspace</title>
+    <link rel="stylesheet" href="./styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <script type="module" src="./app.js" defer></script>
+  </head>
+  <body>
+    <header class="app-header">
+      <div>
+        <h1>Imme Workspace Control Center</h1>
+        <p>Monitor projects, tasks, and workspace health in a focused dark mode layout.</p>
+      </div>
+      <button class="refresh-button" type="button" aria-label="Refresh workspace data">
+        Refresh
+      </button>
+    </header>
+    <main class="app-main">
+      <section class="workspace-summary" aria-labelledby="workspace-summary-title">
+        <h2 id="workspace-summary-title">Workspace Summary</h2>
+        <dl class="summary-grid">
+          <div>
+            <dt>Name</dt>
+            <dd data-field="workspace-name">&mdash;</dd>
+          </div>
+          <div>
+            <dt>Environment</dt>
+            <dd data-field="workspace-environment">&mdash;</dd>
+          </div>
+          <div>
+            <dt>Log Path</dt>
+            <dd data-field="workspace-log">&mdash;</dd>
+          </div>
+          <div>
+            <dt>Database</dt>
+            <dd data-field="workspace-database">&mdash;</dd>
+          </div>
+          <div>
+            <dt>Last Updated</dt>
+            <dd data-field="workspace-updated">&mdash;</dd>
+          </div>
+        </dl>
+      </section>
+      <section class="projects" aria-labelledby="projects-title">
+        <div class="section-header">
+          <h2 id="projects-title">Projects</h2>
+          <p class="section-subtitle">Select a project to review its tasks and current status.</p>
+        </div>
+        <ul class="project-list" role="list"></ul>
+      </section>
+      <section class="tasks" aria-labelledby="tasks-title">
+        <div class="section-header">
+          <h2 id="tasks-title">Tasks</h2>
+          <p class="section-subtitle" data-field="tasks-context">
+            Choose a project to load its tasks.
+          </p>
+        </div>
+        <ul class="task-list" role="list" aria-live="polite"></ul>
+      </section>
+    </main>
+    <footer class="app-footer">
+      <p>
+        Built with empathy for contributors &mdash; following the Laws of UX to stay clear,
+        consistent, and calm.
+      </p>
+    </footer>
+  </body>
+</html>

--- a/src/web/public/styles.css
+++ b/src/web/public/styles.css
@@ -1,0 +1,238 @@
+:root {
+  color-scheme: dark;
+  --color-background: #2f212f;
+  --color-surface: #3a2d3f;
+  --color-surface-alt: #565a7b;
+  --color-muted: #8c8789;
+  --color-highlight: #eaf0ec;
+  --color-focus: #d2d8f9;
+  --font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(135deg, rgba(47, 33, 47, 0.95), rgba(86, 90, 123, 0.6));
+  color: var(--color-highlight);
+  font-family: var(--font-family);
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 2.5rem clamp(1.5rem, 4vw, 3.5rem) 2rem;
+  background: rgba(47, 33, 47, 0.9);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid rgba(234, 240, 236, 0.08);
+}
+
+.app-header h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+}
+
+.app-header p {
+  margin: 0;
+  max-width: 32rem;
+  color: var(--color-muted);
+}
+
+.refresh-button {
+  background: var(--color-surface-alt);
+  color: var(--color-highlight);
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 1.5rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  box-shadow: 0 12px 20px rgba(0, 0, 0, 0.2);
+  transition: transform 150ms ease, box-shadow 150ms ease, background 150ms ease;
+}
+
+.refresh-button:hover,
+.refresh-button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 24px rgba(0, 0, 0, 0.25);
+  outline: none;
+}
+
+.refresh-button:focus-visible {
+  box-shadow: 0 0 0 4px rgba(210, 216, 249, 0.4);
+}
+
+.app-main {
+  display: grid;
+  gap: 2rem;
+  padding: 2rem clamp(1.5rem, 4vw, 3.5rem) 3rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.workspace-summary,
+.projects,
+.tasks {
+  background: rgba(58, 45, 63, 0.85);
+  border-radius: 1.5rem;
+  padding: 1.75rem;
+  box-shadow: 0 20px 40px rgba(15, 8, 22, 0.35);
+  border: 1px solid rgba(234, 240, 236, 0.05);
+}
+
+.workspace-summary h2,
+.section-header h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.4rem;
+}
+
+.section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.section-subtitle {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.summary-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  margin: 1.5rem 0 0;
+}
+
+.summary-grid dt {
+  margin: 0 0 0.35rem;
+  color: var(--color-muted);
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.summary-grid dd {
+  margin: 0;
+  font-size: 1rem;
+  word-break: break-word;
+}
+
+.project-list,
+.task-list {
+  list-style: none;
+  margin: 1.5rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.project-card,
+.task-card {
+  border-radius: 1.1rem;
+  padding: 1.25rem;
+  background: rgba(86, 90, 123, 0.55);
+  border: 1px solid transparent;
+  transition: transform 160ms ease, border-color 160ms ease, background 160ms ease;
+  position: relative;
+}
+
+.project-card button {
+  all: unset;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  cursor: pointer;
+}
+
+.project-card:hover,
+.project-card:focus-within {
+  transform: translateY(-4px);
+  border-color: rgba(234, 240, 236, 0.35);
+  background: rgba(86, 90, 123, 0.75);
+}
+
+.project-card.active {
+  border-color: rgba(210, 216, 249, 0.8);
+  box-shadow: 0 0 0 3px rgba(210, 216, 249, 0.2);
+}
+
+.project-card h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.project-card p {
+  margin: 0;
+  color: rgba(234, 240, 236, 0.8);
+}
+
+.status-pill {
+  align-self: flex-start;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-background);
+  background: var(--color-highlight);
+}
+
+.status-pill[data-status="proposed"] {
+  background: rgba(234, 240, 236, 0.6);
+}
+
+.status-pill[data-status="active"] {
+  background: rgba(234, 240, 236, 0.85);
+}
+
+.status-pill[data-status="complete"] {
+  background: rgba(162, 221, 186, 0.85);
+}
+
+.task-card h3 {
+  margin: 0 0 0.25rem;
+  font-size: 1rem;
+}
+
+.task-card p {
+  margin: 0.25rem 0 0;
+  color: rgba(234, 240, 236, 0.72);
+  line-height: 1.5;
+}
+
+.task-card .status-pill {
+  margin-top: 0.5rem;
+}
+
+.empty-state {
+  margin: 1rem 0 0;
+  color: rgba(234, 240, 236, 0.65);
+  font-style: italic;
+}
+
+.app-footer {
+  padding: 1.5rem;
+  text-align: center;
+  color: rgba(234, 240, 236, 0.6);
+  font-size: 0.85rem;
+  border-top: 1px solid rgba(234, 240, 236, 0.08);
+  margin-top: auto;
+}
+
+@media (max-width: 768px) {
+  .app-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  .refresh-button {
+    align-self: flex-end;
+  }
+}

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -1,0 +1,177 @@
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { extname, join, normalize, resolve } from "node:path";
+import process from "node:process";
+import { Buffer } from "node:buffer";
+import { URL } from "node:url";
+
+import {
+  StructuredLogger,
+  createPersistentFileWriter,
+  loadWorkspaceSummary
+} from "../index.js";
+import { SQLiteStorage } from "../storage/sqlite.js";
+
+const DEFAULT_PORT = Number.parseInt(process.env.PORT ?? "3000", 10);
+const PUBLIC_DIR = resolve(process.cwd(), "src", "web", "public");
+
+const MIME_TYPES = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "application/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".svg": "image/svg+xml"
+};
+
+function createLogger() {
+  let persistentWriter;
+  try {
+    persistentWriter = createPersistentFileWriter({
+      filePath: resolve(process.cwd(), ".imme", "web.log.jsonl")
+    });
+  } catch (error) {
+    console.error("Failed to create web server log file:", error.message);
+  }
+
+  return new StructuredLogger({
+    persistentWriter: persistentWriter ?? console,
+    ephemeralWriter: console,
+    baseContext: {
+      filename: "web/server.js",
+      classname: "WebServer"
+    }
+  });
+}
+
+function sendJson(res, statusCode, payload) {
+  const body = JSON.stringify(payload);
+  res.statusCode = statusCode;
+  res.setHeader("Content-Type", "application/json; charset=utf-8");
+  res.setHeader("Content-Length", Buffer.byteLength(body));
+  res.end(body);
+}
+
+function safeJoinPublic(pathname) {
+  const normalized = normalize(pathname)
+    .replace(/^(\.{2}[/\\])+/, "")
+    .replace(/^\.\/+/, "");
+  return join(PUBLIC_DIR, normalized);
+}
+
+export function start({ port = DEFAULT_PORT } = {}) {
+  const logger = createLogger();
+  const { workspace } = loadWorkspaceSummary();
+  const storage = new SQLiteStorage({ filePath: workspace.databasePath, logger });
+
+  const server = createServer(async (req, res) => {
+    const requestUrl = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+    const { pathname } = requestUrl;
+
+    logger.info({
+      functionName: "request",
+      method: req.method ?? "NONE",
+      message: `${req.method ?? "GET"} ${pathname}`,
+      systemSection: pathname.startsWith("/api/") ? "api" : "static"
+    });
+
+    try {
+      if (pathname === "/api/workspace") {
+        await handleWorkspaceApi({ res });
+        return;
+      }
+
+      if (pathname.startsWith("/api/projects")) {
+        await handleProjectsApi({ req, res, pathname, storage });
+        return;
+      }
+
+      await handleStatic({ pathname, res });
+    } catch (error) {
+      logger.error({
+        functionName: "request",
+        message: error.message,
+        error,
+        systemSection: "api",
+        dbPhase: "none"
+      });
+      sendJson(res, 500, { error: "Internal Server Error" });
+    }
+  });
+
+  server.listen(port, () => {
+    logger.info({
+      functionName: "listen",
+      message: `Web server listening on http://localhost:${port}`,
+      systemSection: "startup"
+    });
+  });
+
+  const shutdown = () => {
+    logger.info({
+      functionName: "shutdown",
+      message: "Shutting down web server",
+      systemSection: "shutdown"
+    });
+    server.close();
+    storage.close();
+  };
+
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+
+  return { server, storage, logger };
+}
+
+async function handleProjectsApi({ req, res, pathname, storage }) {
+  if (req.method !== "GET") {
+    sendJson(res, 405, { error: "Method Not Allowed" });
+    return;
+  }
+
+  const segments = pathname.split("/").filter(Boolean);
+  if (segments.length === 2) {
+    const projects = storage.listProjects();
+    sendJson(res, 200, { projects });
+    return;
+  }
+
+  if (segments.length === 4 && segments[2] === "tasks") {
+    const projectId = segments[1];
+    const tasks = storage.listTasksByProject(projectId);
+    sendJson(res, 200, { tasks });
+    return;
+  }
+
+  sendJson(res, 404, { error: "Not Found" });
+}
+
+async function handleWorkspaceApi({ res }) {
+  const { workspace } = loadWorkspaceSummary();
+  sendJson(res, 200, { workspace });
+}
+
+async function handleStatic({ pathname, res }) {
+  let target = pathname;
+  if (target === "/") {
+    target = "/index.html";
+  }
+
+  const filePath = safeJoinPublic(target);
+  if (!filePath.startsWith(PUBLIC_DIR) || !existsSync(filePath)) {
+    res.statusCode = 404;
+    res.end("Not Found");
+    return;
+  }
+
+  const extension = extname(filePath).toLowerCase();
+  const mimeType = MIME_TYPES[extension] ?? "application/octet-stream";
+  const contents = await readFile(filePath);
+  res.statusCode = 200;
+  res.setHeader("Content-Type", mimeType);
+  res.end(contents);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  start();
+}

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,6 +1,6 @@
 import process from "node:process";
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -9,6 +9,7 @@ import {
   parseArgs,
   runConfigCommand
 } from "../bin/imme.js";
+import { loadWorkspaceSummary } from "../src/index.js";
 
 function withTempCwd(callback) {
   const originalCwd = process.cwd();
@@ -46,5 +47,32 @@ test("runConfigCommand init and set manage configuration", () => {
     runConfigCommand(["set", "--key", "workspace.owner", "--value", "\"qa\""]);
     const updated = JSON.parse(readFileSync(configPath, "utf8"));
     assert.equal(updated.workspace.owner, "qa");
+  });
+});
+
+test("workspace subcommands expose derived paths", () => {
+  withTempCwd(() => {
+    runConfigCommand(["init", "--name", "Sample", "--environment", "test"]);
+    runConfigCommand([
+      "workspace",
+      "set",
+      "--log-path",
+      "./custom/log.jsonl",
+      "--database-path",
+      "./custom/data/imme.sqlite",
+      "--name",
+      "Workspace One"
+    ]);
+
+    const { workspace } = loadWorkspaceSummary();
+    assert.equal(workspace.name, "Workspace One");
+    assert.equal(
+      workspace.logPath,
+      resolve(process.cwd(), "./custom/log.jsonl")
+    );
+    assert.equal(
+      workspace.databasePath,
+      resolve(process.cwd(), "./custom/data/imme.sqlite")
+    );
   });
 });

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -11,6 +11,7 @@ import {
   resolveConfigPath,
   updateConfigValue
 } from "../src/index.js";
+import { updateWorkspaceConfig, loadWorkspaceSummary } from "../src/index.js";
 
 function createTempDir() {
   return mkdtempSync(join(tmpdir(), "imme-config-"));
@@ -77,6 +78,20 @@ test("loadConfig throws on invalid JSON", () => {
     ensureConfig({ cwd });
     writeFileSync(filePath, "not-json", "utf8");
     assert.throws(() => loadConfig({ cwd }), /Invalid configuration JSON/);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("updateWorkspaceConfig tracks workspace paths", () => {
+  const cwd = createTempDir();
+
+  try {
+    ensureConfig({ cwd });
+    updateWorkspaceConfig({ cwd, updates: { logPath: "./logs/app.jsonl", databasePath: "./data/app.db" } });
+    const summary = loadWorkspaceSummary({ cwd });
+    assert.ok(summary.workspace.logPath.endsWith("logs/app.jsonl"));
+    assert.ok(summary.workspace.databasePath.endsWith("data/app.db"));
   } finally {
     rmSync(cwd, { recursive: true, force: true });
   }

--- a/test/sqlite-storage.test.js
+++ b/test/sqlite-storage.test.js
@@ -1,0 +1,53 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { SQLiteStorage } from "../src/storage/sqlite.js";
+
+function withStorage(callback) {
+  const cwd = mkdtempSync(join(tmpdir(), "imme-sqlite-"));
+  const dbPath = join(cwd, "workspace", "imme.db");
+  const storage = new SQLiteStorage({ filePath: dbPath });
+
+  try {
+    callback(storage, dbPath);
+  } finally {
+    storage.close();
+    rmSync(cwd, { recursive: true, force: true });
+  }
+}
+
+test("SQLiteStorage persists projects and tasks", () => {
+  withStorage((storage, dbPath) => {
+    assert.ok(dbPath.endsWith("imme.db"));
+    const project = storage.createProject({ name: "CLI Rollout" });
+    assert.equal(project.name, "CLI Rollout");
+    assert.equal(project.status, "proposed");
+
+    const fetched = storage.getProjectById(project.id);
+    assert.equal(fetched?.id, project.id);
+
+    storage.updateProject({ id: project.id, status: "active" });
+    const updated = storage.getProjectById(project.id);
+    assert.equal(updated?.status, "active");
+
+    const task = storage.createTask({
+      projectId: project.id,
+      title: "Ship CLI",
+      assignees: ["dev"],
+      notes: "Focus on config UX"
+    });
+
+    assert.equal(task.projectId, project.id);
+    assert.deepEqual(task.assignees, ["dev"]);
+
+    storage.updateTask({ id: task.id, status: "in_progress" });
+    const refreshedTask = storage.getTaskById(task.id);
+    assert.equal(refreshedTask?.status, "in_progress");
+
+    const tasks = storage.listTasksByProject(project.id);
+    assert.equal(tasks.length, 1);
+  });
+});


### PR DESCRIPTION
## Summary
- expand the `imme config` command with workspace-specific flows for showing, updating, and locating configuration data
- implement a SQLite storage layer with migrations plus documentation outlining the database option evaluation
- add a dark-mode web dashboard backed by the shared API, including UX notes aligned with the Laws of UX

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68deea3a4430832b84329741e80ec47a