### PR TITLE
Add config drift detection and project editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Imme Workspace
 
-This repository is being built iteratively. The initial milestone establishes a Node.js project skeleton with linting, unit tests, and a structured logger that follows the mandated canonical schema.
+## Purpose
+Imme Workspace is a Node.js toolchain that unifies structured logging, configuration governance, and project tracking for the Imme program. The repository ships a CLI, SQLite-backed persistence layer, and a dark-mode web dashboard so contributors can manage work with consistent telemetry and observability.
+
+## Roadmap status
+- Outstanding tasks: none — every backlog item tracked in `project-manager/task.md` is complete.
+- Latest milestone: automated configuration drift detection and a browser-based project editor are now available for day-to-day operations.
 
 ## Getting started
 
@@ -33,7 +38,7 @@ const logger = new StructuredLogger({
 logger.info({ message: "Boot sequence complete", functionName: "main" });
 ```
 
-## CLI logging tool
+## CLI logging & configuration management
 
 Install the CLI locally to emit structured logs from the terminal:
 
@@ -42,13 +47,9 @@ npm link
 imme log --message "hello" --filename cli.js
 ```
 
-Entries are appended to `.imme/logs.jsonl` by default. The CLI accepts
-additional context fields (`--system-section`, `--method`, `--db-phase`, etc.)
-that match the canonical log schema.
+Entries are appended to `.imme/logs.jsonl` by default. The CLI accepts additional context fields (`--system-section`, `--method`, `--db-phase`, etc.) that match the canonical log schema.
 
-## Workspace configuration management
-
-Use the `config` subcommands to manage workspace defaults:
+Configuration lives at `.imme/config.json` and should be committed whenever team defaults change. Use the `config` subcommands to manage workspace defaults and verify configuration drift:
 
 ```bash
 # Create or refresh the configuration file
@@ -60,26 +61,23 @@ imme config show
 # Update individual fields using dot-notation keys
 imme config set --key workspace.environment --value production
 
+# Detect drift between your local config and the tracked baseline
+imme config drift
+
 # Update workspace metadata via guided flags
 imme config workspace set --environment staging --log-path ./artifacts/log.jsonl
 ```
 
-Configuration lives at `.imme/config.json` and should be committed whenever team
-defaults change. The CLI automatically stamps each update with an ISO-8601
-`lastUpdated` timestamp. Run `imme config workspace show` to view resolved paths
-and SQLite connection details.
+The CLI automatically stamps each update with an ISO-8601 `lastUpdated` timestamp. Run `imme config workspace show` to view resolved paths and SQLite connection details. `imme config drift` exits with code `1` when local changes diverge from the committed baseline, making it suitable for CI enforcement.
 
 ## SQLite-backed storage
 
-Projects and tasks now persist to a SQLite database located at
-`.imme/imme.db` (configurable via the CLI). The `SQLiteStorage` class under
-`src/storage/sqlite.js` exposes CRUD helpers that mirror the domain model.
+Projects and tasks persist to a SQLite database located at `.imme/imme.db` (configurable via the CLI). The `SQLiteStorage` class under `src/storage/sqlite.js` exposes CRUD helpers that mirror the domain model.
 
-- Migrations run automatically on startup and are versioned within the source
-  tree.
+- Migrations run automatically on startup and are versioned within the source tree.
 - Tests use temporary databases to keep fixtures isolated.
 
-## Dark mode web UI
+## Dark mode web UI & project editor
 
 Launch the workspace dashboard with:
 
@@ -87,10 +85,6 @@ Launch the workspace dashboard with:
 npm run web
 ```
 
-The server reads the shared SQLite database and exposes read-only APIs under
-`/api`. Visit `http://localhost:3000` to view workspace health, projects, and
-tasks. The interface follows the provided palette and the Laws of UX for a
-focused, high-contrast experience.
+Visit `http://localhost:3000` to view workspace health, projects, and tasks. The interface follows the provided palette and the Laws of UX for a focused, high-contrast experience. The dashboard now includes a project editor that can create new projects or update the currently selected project via the `/api/projects` POST and PUT endpoints. Use the Refresh button to sync the view after CLI-driven changes.
 
-Refer to `docs/runbook.md` for operational procedures and
-`docs/onboarding.md` for contributor guidelines.
+Refer to `docs/runbook.md` for operational procedures and `docs/onboarding.md` for contributor guidelines.

--- a/bin/imme.js
+++ b/bin/imme.js
@@ -14,7 +14,9 @@ import {
   loadWorkspaceSummary,
   updateConfigValue,
   updateWorkspaceConfig,
-  resolveConfigPath
+  resolveConfigPath,
+  detectConfigDrift,
+  formatDriftReport
 } from "../src/index.js";
 
 const require = createRequire(import.meta.url);
@@ -48,6 +50,7 @@ function printUsage() {
   console.log("  init                  Create a workspace configuration file");
   console.log("  show                  Display the current configuration");
   console.log("  set --key <path> --value <value>   Update a configuration value");
+  console.log("  drift                Detect configuration drift against the current HEAD");
   console.log("  workspace <action>    Manage workspace metadata (see --help)");
 }
 
@@ -59,6 +62,7 @@ function printConfigUsage() {
   console.log(`  ${scriptName} config init [--force] [--name <text>] [--environment <text>]`);
   console.log(`  ${scriptName} config show`);
   console.log(`  ${scriptName} config set --key <path> --value <value>`);
+  console.log(`  ${scriptName} config drift`);
   console.log(`  ${scriptName} config workspace show`);
   console.log(
     `  ${scriptName} config workspace set [--name <text>] [--environment <text>] [--log-path <path>] [--database-path <path>]`
@@ -378,6 +382,16 @@ function runConfigCommand(args) {
 
       const { filePath } = updateConfigValue({ keyPath: options.key, value: options.value });
       console.log(`Updated ${options.key} in ${filePath}`);
+      return;
+    }
+
+    case "drift": {
+      const result = detectConfigDrift();
+      const report = formatDriftReport(result);
+      console.log(report);
+      if (result.hasDrift) {
+        process.exitCode = 1;
+      }
       return;
     }
 

--- a/project-manager/task.md
+++ b/project-manager/task.md
@@ -16,8 +16,9 @@ This document tracks progress for the Imme project. Checkboxes reflect the curre
 - [x] Implemented SQLite-backed persistence for projects and tasks.
 - [x] Delivered a dark-mode web UI for monitoring workspace health.
 - [x] Documented trade-offs between SQLite, PostgreSQL, and document stores.
+- [x] Automated configuration drift detection (notifies when `.imme/config.json` diverges across clones).
+- [x] Expanded the web API and UI to support creating and updating projects directly from the dashboard.
 
 ## 🔄 In Progress / Backlog
 
-- [ ] Automate configuration drift detection (notify when `.imme/config.json` diverges across clones).
-- [ ] Expand the web API to support creating and updating projects from the UI.
+_No open items. Capture new tasks below as the roadmap evolves._

--- a/src/config-drift.js
+++ b/src/config-drift.js
@@ -1,0 +1,221 @@
+import process from "node:process";
+import { readFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const DEFAULT_RELATIVE_PATH = ".imme/config.json";
+const IGNORED_PATHS = new Set(["workspace.lastUpdated"]);
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function canonicalize(value) {
+  if (Array.isArray(value)) {
+    return value.map((item) => canonicalize(item));
+  }
+
+  if (isPlainObject(value)) {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort((left, right) => (left < right ? -1 : left > right ? 1 : 0))
+        .map((key) => [key, canonicalize(value[key])])
+    );
+  }
+
+  return value;
+}
+
+function valuesEqual(left, right) {
+  return JSON.stringify(canonicalize(left)) === JSON.stringify(canonicalize(right));
+}
+
+function parseJson(contents, label) {
+  try {
+    return JSON.parse(contents);
+  } catch (error) {
+    throw new Error(`Failed to parse ${label}: ${error.message}`);
+  }
+}
+
+function collectDiffs(baselineValue, localValue, pathSegments, diffs) {
+  const pathKey = pathSegments.join(".");
+  if (IGNORED_PATHS.has(pathKey)) {
+    return;
+  }
+
+  if (!isPlainObject(baselineValue) && !isPlainObject(localValue)) {
+    if (!valuesEqual(baselineValue, localValue)) {
+      diffs.push({
+        type: "changed",
+        path: pathKey,
+        baseline: baselineValue ?? null,
+        local: localValue ?? null
+      });
+    }
+    return;
+  }
+
+  const baselineObject = isPlainObject(baselineValue) ? baselineValue : {};
+  const localObject = isPlainObject(localValue) ? localValue : {};
+
+  const keys = new Set([...Object.keys(baselineObject), ...Object.keys(localObject)]);
+  const sortedKeys = Array.from(keys).sort((left, right) => (left < right ? -1 : left > right ? 1 : 0));
+
+  for (const key of sortedKeys) {
+    const nextPath = [...pathSegments, key];
+    const hasBaseline = Object.hasOwn(baselineObject, key);
+    const hasLocal = Object.hasOwn(localObject, key);
+
+    if (!hasBaseline && hasLocal) {
+      if (!IGNORED_PATHS.has(nextPath.join("."))) {
+        diffs.push({
+          type: "added",
+          path: nextPath.join("."),
+          baseline: null,
+          local: localObject[key]
+        });
+      }
+      continue;
+    }
+
+    if (hasBaseline && !hasLocal) {
+      if (!IGNORED_PATHS.has(nextPath.join("."))) {
+        diffs.push({
+          type: "removed",
+          path: nextPath.join("."),
+          baseline: baselineObject[key],
+          local: null
+        });
+      }
+      continue;
+    }
+
+    collectDiffs(baselineObject[key], localObject[key], nextPath, diffs);
+  }
+}
+
+function loadBaselineConfig({ cwd, relativePath }) {
+  const gitShow = spawnSync("git", ["show", `HEAD:${relativePath}`], {
+    cwd,
+    encoding: "utf8"
+  });
+
+  if (gitShow.status === 0 && gitShow.stdout.trim().length > 0) {
+    const baseline = parseJson(gitShow.stdout, `baseline config at HEAD:${relativePath}`);
+    return { baseline, source: "git" };
+  }
+
+  const gitDirCheck = spawnSync("git", ["rev-parse", "--is-inside-work-tree"], {
+    cwd,
+    encoding: "utf8"
+  });
+
+  const gitAvailable = gitDirCheck.status === 0;
+  if (gitAvailable) {
+    return { baseline: null, source: "git-missing" };
+  }
+
+  return { baseline: null, source: "unavailable" };
+}
+
+function loadLocalConfig({ cwd, relativePath }) {
+  const filePath = resolve(cwd, relativePath);
+  if (!existsSync(filePath)) {
+    return { config: null, filePath, exists: false };
+  }
+
+  const contents = readFileSync(filePath, "utf8");
+  if (contents.trim().length === 0) {
+    return { config: {}, filePath, exists: true };
+  }
+
+  const config = parseJson(contents, `local config at ${filePath}`);
+  return { config, filePath, exists: true };
+}
+
+export function detectConfigDrift({ cwd = process.cwd(), relativePath = DEFAULT_RELATIVE_PATH } = {}) {
+  const baselineResult = loadBaselineConfig({ cwd, relativePath });
+  const localResult = loadLocalConfig({ cwd, relativePath });
+
+  if (!localResult.exists) {
+    return {
+      hasDrift: true,
+      reason: "local-missing",
+      filePath: localResult.filePath,
+      differences: [
+        {
+          type: "missing",
+          path: relativePath,
+          baseline: baselineResult.baseline,
+          local: null
+        }
+      ],
+      baselineSource: baselineResult.source
+    };
+  }
+
+  if (!baselineResult.baseline) {
+    return {
+      hasDrift: false,
+      reason: baselineResult.source,
+      filePath: localResult.filePath,
+      differences: [],
+      baselineSource: baselineResult.source
+    };
+  }
+
+  const diffs = [];
+  collectDiffs(baselineResult.baseline, localResult.config, [], diffs);
+
+  return {
+    hasDrift: diffs.length > 0,
+    reason: diffs.length > 0 ? "differences" : "in-sync",
+    filePath: localResult.filePath,
+    differences: diffs,
+    baselineSource: baselineResult.source
+  };
+}
+
+export function formatDriftReport({
+  hasDrift,
+  differences,
+  baselineSource,
+  filePath,
+  reason
+}) {
+  if (!hasDrift) {
+    if (baselineSource === "git" || baselineSource === "git-missing") {
+      return `No configuration drift detected for ${filePath}.`;
+    }
+    return `No baseline detected (source: ${baselineSource}). Local configuration treated as authoritative.`;
+  }
+
+  if (reason === "local-missing") {
+    return `Configuration file missing at ${filePath}.`;
+  }
+
+  const lines = ["Configuration drift detected:"];
+  for (const diff of differences) {
+    switch (diff.type) {
+      case "added":
+        lines.push(`  • Added ${diff.path}: ${JSON.stringify(diff.local)}`);
+        break;
+      case "removed":
+        lines.push(`  • Removed ${diff.path}: ${JSON.stringify(diff.baseline)}`);
+        break;
+      case "changed":
+        lines.push(
+          `  • Changed ${diff.path}: ${JSON.stringify(diff.baseline)} → ${JSON.stringify(diff.local)}`
+        );
+        break;
+      case "missing":
+        lines.push(`  • Missing configuration at ${diff.path}`);
+        break;
+      default:
+        lines.push(`  • ${diff.path || '<root>'} differs`);
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/src/index.js
+++ b/src/index.js
@@ -14,3 +14,4 @@ export {
   writeConfig
 } from "./config.js";
 export { SQLiteStorage, createSQLiteStorage } from "./storage/sqlite.js";
+export { detectConfigDrift, formatDriftReport } from "./config-drift.js";

--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -3,6 +3,7 @@
 
 const state = {
   selectedProjectId: null,
+  editorProjectId: null,
   projects: [],
   tasks: []
 };
@@ -13,13 +14,21 @@ const fields = {
   logPath: document.querySelector('[data-field="workspace-log"]'),
   database: document.querySelector('[data-field="workspace-database"]'),
   updated: document.querySelector('[data-field="workspace-updated"]'),
-  tasksContext: document.querySelector('[data-field="tasks-context"]')
+  tasksContext: document.querySelector('[data-field="tasks-context"]'),
+  editorMode: document.querySelector('[data-field="editor-mode"]'),
+  projectFeedback: document.querySelector('[data-field="project-feedback"]')
 };
 
 const elements = {
   refresh: document.querySelector('.refresh-button'),
   projectList: document.querySelector('.project-list'),
-  taskList: document.querySelector('.task-list')
+  taskList: document.querySelector('.task-list'),
+  projectForm: document.querySelector('.project-form'),
+  projectName: document.querySelector('[name="project-name"]'),
+  projectDescription: document.querySelector('[name="project-description"]'),
+  projectStatus: document.querySelector('[name="project-status"]'),
+  projectReset: document.querySelector('[data-action="reset-editor"]'),
+  projectSubmit: document.querySelector('[data-action="submit-project"]')
 };
 
 async function fetchJson(url) {
@@ -44,6 +53,72 @@ function formatDate(value) {
   }).format(date);
 }
 
+function populateEditorFields(project) {
+  if (!elements.projectForm) {
+    return;
+  }
+
+  elements.projectName.value = project?.name ?? '';
+  elements.projectDescription.value = project?.description ?? '';
+  elements.projectStatus.value = project?.status ?? 'proposed';
+}
+
+function updateEditorModeCopy() {
+  if (!fields.editorMode || !elements.projectSubmit || !elements.projectReset) {
+    return;
+  }
+
+  if (state.editorProjectId) {
+    fields.editorMode.textContent = 'Editing the selected project. Changes persist immediately after saving.';
+    elements.projectSubmit.textContent = 'Update Project';
+    elements.projectReset.textContent = 'Switch to Create Mode';
+  } else {
+    fields.editorMode.textContent = 'Create a new project to track upcoming work.';
+    elements.projectSubmit.textContent = 'Create Project';
+    elements.projectReset.textContent = 'Clear';
+  }
+}
+
+function setEditorProject(project) {
+  state.editorProjectId = project?.id ?? null;
+  populateEditorFields(project ?? null);
+  updateEditorModeCopy();
+}
+
+function resetProjectEditor() {
+  setEditorProject(null);
+  clearProjectFeedback();
+}
+
+function clearProjectFeedback() {
+  if (!fields.projectFeedback) {
+    return;
+  }
+  fields.projectFeedback.textContent = '';
+  delete fields.projectFeedback.dataset.variant;
+}
+
+function showProjectFeedback(message, variant = 'info') {
+  if (!fields.projectFeedback) {
+    return;
+  }
+  fields.projectFeedback.textContent = message;
+  fields.projectFeedback.dataset.variant = variant;
+}
+
+function setProjectFormBusy(isBusy) {
+  if (!elements.projectForm) {
+    return;
+  }
+  if (isBusy) {
+    elements.projectForm.setAttribute('aria-busy', 'true');
+  } else {
+    elements.projectForm.removeAttribute('aria-busy');
+  }
+  elements.projectSubmit.disabled = isBusy;
+  elements.projectReset.disabled = isBusy;
+}
+
 function renderWorkspaceSummary(workspace) {
   fields.name.textContent = workspace.name;
   fields.environment.textContent = workspace.environment;
@@ -57,7 +132,7 @@ function renderProjects(projects) {
   if (projects.length === 0) {
     const empty = document.createElement('li');
     empty.className = 'empty-state';
-    empty.textContent = 'No projects yet. Create one via the CLI to get started.';
+    empty.textContent = 'No projects yet. Use the editor below to create your first project.';
     elements.projectList.appendChild(empty);
     return;
   }
@@ -146,6 +221,16 @@ async function loadProjects() {
   state.projects = projects;
   if (state.selectedProjectId && !projects.some((project) => project.id === state.selectedProjectId)) {
     state.selectedProjectId = null;
+    resetProjectEditor();
+  } else if (state.editorProjectId) {
+    const project = projects.find((item) => item.id === state.editorProjectId);
+    if (project) {
+      populateEditorFields(project);
+    } else {
+      resetProjectEditor();
+    }
+  } else {
+    updateEditorModeCopy();
   }
   renderProjects(projects);
   if (state.selectedProjectId) {
@@ -163,8 +248,75 @@ async function loadTasks(projectId) {
 
 async function selectProject(projectId) {
   state.selectedProjectId = projectId;
+  const project = state.projects.find((item) => item.id === projectId);
+  if (project) {
+    setEditorProject(project);
+  }
   renderProjects(state.projects);
   await loadTasks(projectId);
+}
+
+async function handleProjectSubmit(event) {
+  event.preventDefault();
+  clearProjectFeedback();
+
+  const name = elements.projectName.value.trim();
+  const description = elements.projectDescription.value.trim();
+  const status = elements.projectStatus.value;
+
+  if (!name) {
+    showProjectFeedback('Project name is required.', 'error');
+    elements.projectName.focus();
+    return;
+  }
+
+  const payload = { name, description, status };
+  setProjectFormBusy(true);
+
+  try {
+    const endpoint = state.editorProjectId ? `/api/projects/${state.editorProjectId}` : '/api/projects';
+    const method = state.editorProjectId ? 'PUT' : 'POST';
+    const response = await fetch(endpoint, {
+      method,
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(payload)
+    });
+
+    let result = {};
+    try {
+      result = await response.json();
+    } catch {
+      result = {};
+    }
+
+    if (!response.ok) {
+      throw new Error(result.error ?? `Request failed with status ${response.status}`);
+    }
+
+    if (!result.project) {
+      throw new Error('Unexpected API response: missing project payload.');
+    }
+
+    const successMessage = state.editorProjectId ? 'Project updated successfully.' : 'Project created successfully.';
+    showProjectFeedback(successMessage, 'success');
+
+    state.selectedProjectId = result.project.id;
+    setEditorProject(result.project);
+
+    try {
+      await loadProjects();
+    } catch (refreshError) {
+      console.error('Project saved but refresh failed:', refreshError);
+      showProjectFeedback(`${successMessage} Refresh failed: ${refreshError.message}`, 'warning');
+    }
+  } catch (error) {
+    console.error('Project submission failed:', error);
+    showProjectFeedback(error.message, 'error');
+  } finally {
+    setProjectFormBusy(false);
+  }
 }
 
 async function refresh() {
@@ -185,6 +337,18 @@ elements.refresh.addEventListener('click', () => {
   refresh();
 });
 
+if (elements.projectForm) {
+  elements.projectForm.addEventListener('submit', handleProjectSubmit);
+}
+
+if (elements.projectReset) {
+  elements.projectReset.addEventListener('click', (event) => {
+    event.preventDefault();
+    resetProjectEditor();
+  });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
+  resetProjectEditor();
   refresh();
 });

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -56,6 +56,53 @@
         </div>
         <ul class="project-list" role="list"></ul>
       </section>
+      <section class="project-editor" aria-labelledby="project-editor-title">
+        <div class="section-header">
+          <h2 id="project-editor-title">Project Editor</h2>
+          <p class="section-subtitle" data-field="editor-mode">
+            Create a new project to track upcoming work.
+          </p>
+        </div>
+        <form class="project-form" autocomplete="off" novalidate>
+          <div class="field-group">
+            <label>
+              <span>Project name</span>
+              <input
+                type="text"
+                name="project-name"
+                required
+                maxlength="120"
+                placeholder="e.g., Observability rollout"
+              />
+            </label>
+          </div>
+          <div class="field-group">
+            <label>
+              <span>Description</span>
+              <textarea
+                name="project-description"
+                rows="3"
+                placeholder="What problem are we solving?"
+              ></textarea>
+            </label>
+          </div>
+          <div class="field-group">
+            <label>
+              <span>Status</span>
+              <select name="project-status">
+                <option value="proposed">Proposed</option>
+                <option value="active">Active</option>
+                <option value="complete">Complete</option>
+              </select>
+            </label>
+          </div>
+          <div class="form-actions">
+            <button type="submit" data-action="submit-project">Create Project</button>
+            <button type="button" data-action="reset-editor">Clear</button>
+          </div>
+        </form>
+        <p class="form-feedback" data-field="project-feedback" role="status" aria-live="polite"></p>
+      </section>
       <section class="tasks" aria-labelledby="tasks-title">
         <div class="section-header">
           <h2 id="tasks-title">Tasks</h2>

--- a/src/web/public/styles.css
+++ b/src/web/public/styles.css
@@ -77,7 +77,8 @@ body {
 
 .workspace-summary,
 .projects,
-.tasks {
+.tasks,
+.project-editor {
   background: rgba(58, 45, 63, 0.85);
   border-radius: 1.5rem;
   padding: 1.75rem;
@@ -130,6 +131,94 @@ body {
   padding: 0;
   display: grid;
   gap: 1rem;
+}
+
+.project-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.field-group label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  font-weight: 500;
+  color: var(--color-highlight);
+}
+
+.field-group input,
+.field-group textarea,
+.field-group select {
+  background: rgba(86, 90, 123, 0.35);
+  border: 1px solid rgba(234, 240, 236, 0.15);
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  color: var(--color-highlight);
+  font: inherit;
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+.field-group textarea {
+  resize: vertical;
+}
+
+.field-group input:focus-visible,
+.field-group textarea:focus-visible,
+.field-group select:focus-visible {
+  outline: none;
+  border-color: rgba(210, 216, 249, 0.65);
+  box-shadow: 0 0 0 3px rgba(210, 216, 249, 0.25);
+}
+
+.form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.form-actions button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.65rem 1.5rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  color: var(--color-highlight);
+  background: rgba(86, 90, 123, 0.75);
+  transition: transform 120ms ease, box-shadow 120ms ease, background 120ms ease;
+}
+
+.form-actions button[type="submit"] {
+  background: var(--color-surface-alt);
+}
+
+.form-actions button:hover,
+.form-actions button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 18px rgba(0, 0, 0, 0.2);
+  outline: none;
+}
+
+.form-feedback {
+  margin-top: 1rem;
+  min-height: 1.25rem;
+  font-size: 0.9rem;
+  color: rgba(234, 240, 236, 0.75);
+}
+
+.form-feedback[data-variant="error"] {
+  color: #ffb3c1;
+}
+
+.form-feedback[data-variant="success"] {
+  color: #b8f7d4;
+}
+
+.form-feedback[data-variant="warning"] {
+  color: #ffe2a8;
 }
 
 .project-card,

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -15,6 +15,7 @@ import { SQLiteStorage } from "../storage/sqlite.js";
 
 const DEFAULT_PORT = Number.parseInt(process.env.PORT ?? "3000", 10);
 const PUBLIC_DIR = resolve(process.cwd(), "src", "web", "public");
+const MAX_JSON_BODY_SIZE = 1_048_576; // 1 MiB
 
 const MIME_TYPES = {
   ".html": "text/html; charset=utf-8",
@@ -52,17 +53,62 @@ function sendJson(res, statusCode, payload) {
   res.end(body);
 }
 
-function safeJoinPublic(pathname) {
+function safeJoinPublic(publicDir, pathname) {
   const normalized = normalize(pathname)
     .replace(/^(\.{2}[/\\])+/, "")
     .replace(/^\.\/+/, "");
-  return join(PUBLIC_DIR, normalized);
+  return join(publicDir, normalized);
 }
 
-export function start({ port = DEFAULT_PORT } = {}) {
-  const logger = createLogger();
-  const { workspace } = loadWorkspaceSummary();
-  const storage = new SQLiteStorage({ filePath: workspace.databasePath, logger });
+async function readJsonBody(req) {
+  const chunks = [];
+  let totalLength = 0;
+
+  for await (const chunk of req) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    totalLength += buffer.length;
+    if (totalLength > MAX_JSON_BODY_SIZE) {
+      throw new Error("Payload too large");
+    }
+    chunks.push(buffer);
+  }
+
+  if (chunks.length === 0) {
+    return {};
+  }
+
+  const raw = Buffer.concat(chunks).toString("utf8");
+  if (raw.trim().length === 0) {
+    return {};
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`Invalid JSON payload: ${error.message}`);
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("JSON body must be an object");
+  }
+
+  return parsed;
+}
+
+export function start({
+  port = DEFAULT_PORT,
+  workspaceResolver = loadWorkspaceSummary,
+  storageFactory,
+  loggerFactory = createLogger,
+  publicDir = PUBLIC_DIR
+} = {}) {
+  const logger = loggerFactory();
+  const { workspace } = workspaceResolver();
+  const storage =
+    typeof storageFactory === "function"
+      ? storageFactory({ workspace, logger })
+      : new SQLiteStorage({ filePath: workspace.databasePath, logger });
 
   const server = createServer(async (req, res) => {
     const requestUrl = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
@@ -77,16 +123,16 @@ export function start({ port = DEFAULT_PORT } = {}) {
 
     try {
       if (pathname === "/api/workspace") {
-        await handleWorkspaceApi({ res });
+        await handleWorkspaceApi({ res, workspaceResolver });
         return;
       }
 
       if (pathname.startsWith("/api/projects")) {
-        await handleProjectsApi({ req, res, pathname, storage });
+        await handleProjectsApi({ req, res, pathname, storage, logger });
         return;
       }
 
-      await handleStatic({ pathname, res });
+      await handleStatic({ pathname, res, publicDir });
     } catch (error) {
       logger.error({
         functionName: "request",
@@ -123,42 +169,105 @@ export function start({ port = DEFAULT_PORT } = {}) {
   return { server, storage, logger };
 }
 
-async function handleProjectsApi({ req, res, pathname, storage }) {
-  if (req.method !== "GET") {
-    sendJson(res, 405, { error: "Method Not Allowed" });
-    return;
-  }
-
+async function handleProjectsApi({ req, res, pathname, storage, logger }) {
   const segments = pathname.split("/").filter(Boolean);
   if (segments.length === 2) {
-    const projects = storage.listProjects();
-    sendJson(res, 200, { projects });
-    return;
+    if (req.method === "GET") {
+      const projects = storage.listProjects();
+      sendJson(res, 200, { projects });
+      return;
+    }
+
+    if (req.method === "POST") {
+      let body;
+      try {
+        body = await readJsonBody(req);
+      } catch (error) {
+        sendJson(res, 400, { error: error.message });
+        return;
+      }
+
+      try {
+        const project = storage.createProject({
+          name: body.name,
+          description: body.description,
+          status: body.status
+        });
+        sendJson(res, 201, { project });
+        return;
+      } catch (error) {
+        logger.error({
+          functionName: "handleProjectsApi",
+          message: error.message,
+          error,
+          systemSection: "api",
+          method: "POST"
+        });
+        sendJson(res, 400, { error: error.message });
+        return;
+      }
+    }
   }
 
-  if (segments.length === 4 && segments[2] === "tasks") {
-    const projectId = segments[1];
+  if (segments.length === 4 && segments[3] === "tasks") {
+    const projectId = segments[2];
     const tasks = storage.listTasksByProject(projectId);
     sendJson(res, 200, { tasks });
     return;
   }
 
+  if (segments.length === 3 && req.method === "PUT") {
+    const projectId = segments[2];
+    let body;
+    try {
+      body = await readJsonBody(req);
+    } catch (error) {
+      sendJson(res, 400, { error: error.message });
+      return;
+    }
+
+    try {
+      const project = storage.updateProject({
+        id: projectId,
+        name: body.name,
+        description: body.description,
+        status: body.status
+      });
+      sendJson(res, 200, { project });
+      return;
+    } catch (error) {
+      logger.error({
+        functionName: "handleProjectsApi",
+        message: error.message,
+        error,
+        systemSection: "api",
+        method: "PUT"
+      });
+      if (/does not exist/i.test(error.message)) {
+        sendJson(res, 404, { error: error.message });
+      } else {
+        sendJson(res, 400, { error: error.message });
+      }
+      return;
+    }
+  }
+
   sendJson(res, 404, { error: "Not Found" });
 }
 
-async function handleWorkspaceApi({ res }) {
-  const { workspace } = loadWorkspaceSummary();
+async function handleWorkspaceApi({ res, workspaceResolver }) {
+  const { workspace } = workspaceResolver();
   sendJson(res, 200, { workspace });
 }
 
-async function handleStatic({ pathname, res }) {
+async function handleStatic({ pathname, res, publicDir }) {
   let target = pathname;
   if (target === "/") {
     target = "/index.html";
   }
 
-  const filePath = safeJoinPublic(target);
-  if (!filePath.startsWith(PUBLIC_DIR) || !existsSync(filePath)) {
+  const filePath = safeJoinPublic(publicDir, target);
+  if (!filePath.startsWith(publicDir) || !existsSync(filePath)) {
     res.statusCode = 404;
     res.end("Not Found");
     return;

--- a/test/config-drift.test.js
+++ b/test/config-drift.test.js
@@ -1,0 +1,83 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execSync } from "node:child_process";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { detectConfigDrift } from "../src/config-drift.js";
+
+function initGitWorkspace() {
+  const cwd = mkdtempSync(join(tmpdir(), "imme-drift-"));
+  execSync("git init", { cwd, stdio: "ignore" });
+  execSync('git config user.email "imme@example.com"', { cwd, stdio: "ignore" });
+  execSync('git config user.name "Imme Bot"', { cwd, stdio: "ignore" });
+
+  const configDir = join(cwd, ".imme");
+  mkdirSync(configDir, { recursive: true });
+  const baseline = {
+    workspace: {
+      name: "Imme Workspace",
+      environment: "development",
+      lastUpdated: "2024-01-01T00:00:00.000Z"
+    }
+  };
+  writeFileSync(join(configDir, "config.json"), `${JSON.stringify(baseline, null, 2)}\n`);
+  execSync("git add .", { cwd, stdio: "ignore" });
+  execSync('git commit -m "baseline config"', { cwd, stdio: "ignore" });
+
+  return {
+    cwd,
+    cleanup() {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  };
+}
+
+test("detectConfigDrift reports no drift when configuration matches HEAD", () => {
+  const context = initGitWorkspace();
+
+  try {
+    const result = detectConfigDrift({ cwd: context.cwd });
+    assert.equal(result.hasDrift, false);
+    assert.equal(result.baselineSource, "git");
+  } finally {
+    context.cleanup();
+  }
+});
+
+test("detectConfigDrift ignores lastUpdated-only changes", () => {
+  const context = initGitWorkspace();
+
+  try {
+    const configPath = join(context.cwd, ".imme", "config.json");
+    const mutated = JSON.parse(readFileSync(configPath, "utf8"));
+    mutated.workspace.lastUpdated = "2025-02-02T12:34:56.789Z";
+    writeFileSync(configPath, `${JSON.stringify(mutated, null, 2)}\n`);
+
+    const result = detectConfigDrift({ cwd: context.cwd });
+    assert.equal(result.hasDrift, false);
+  } finally {
+    context.cleanup();
+  }
+});
+
+test("detectConfigDrift highlights semantic configuration drift", () => {
+  const context = initGitWorkspace();
+
+  try {
+    const configPath = join(context.cwd, ".imme", "config.json");
+    const mutated = JSON.parse(readFileSync(configPath, "utf8"));
+    mutated.workspace.environment = "production";
+    mutated.workspace.owner = "qa";
+    mutated.workspace.lastUpdated = "2025-02-02T12:34:56.789Z";
+    writeFileSync(configPath, `${JSON.stringify(mutated, null, 2)}\n`);
+
+    const result = detectConfigDrift({ cwd: context.cwd });
+    assert.equal(result.hasDrift, true);
+    const paths = result.differences.map((diff) => diff.path).sort();
+    assert.deepEqual(paths, ["workspace.environment", "workspace.owner"]);
+  } finally {
+    context.cleanup();
+  }
+});

--- a/test/web-server.test.js
+++ b/test/web-server.test.js
@@ -1,0 +1,90 @@
+/* global fetch */
+
+import process from "node:process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { once } from "node:events";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { start } from "../src/web/server.js";
+
+function createWorkspaceContext(tempDir) {
+  const databasePath = join(tempDir, "workspace.db");
+  return {
+    workspace: {
+      name: "Test Workspace",
+      environment: "test",
+      logPath: join(tempDir, "logs.jsonl"),
+      databasePath,
+      database: {
+        client: "sqlite",
+        options: { filename: databasePath }
+      },
+      lastUpdated: new Date().toISOString()
+    }
+  };
+}
+
+function createLoggerStub() {
+  return {
+    info() {},
+    error() {},
+    debug() {},
+    warn() {}
+  };
+}
+
+test("web API allows creating and updating projects", async () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "imme-web-"));
+  const workspaceSummary = createWorkspaceContext(tempDir);
+  const logger = createLoggerStub();
+
+  const context = start({
+    port: 0,
+    workspaceResolver: () => workspaceSummary,
+    loggerFactory: () => logger,
+    publicDir: resolve(process.cwd(), "src", "web", "public")
+  });
+
+  try {
+    await once(context.server, "listening");
+    const address = context.server.address();
+    assert.ok(address && typeof address === "object");
+    const baseUrl = `http://127.0.0.1:${address.port}`;
+
+    const listResponse = await fetch(`${baseUrl}/api/projects`);
+    assert.equal(listResponse.status, 200);
+    const initial = await listResponse.json();
+    assert.deepEqual(initial.projects, []);
+
+    const createResponse = await fetch(`${baseUrl}/api/projects`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Launch", description: "Kickoff", status: "active" })
+    });
+    assert.equal(createResponse.status, 201);
+    const created = await createResponse.json();
+    assert.ok(created.project.id);
+    assert.equal(created.project.status, "active");
+
+    const updateResponse = await fetch(`${baseUrl}/api/projects/${created.project.id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "complete" })
+    });
+    assert.equal(updateResponse.status, 200);
+    const updated = await updateResponse.json();
+    assert.equal(updated.project.status, "complete");
+
+    const tasksResponse = await fetch(`${baseUrl}/api/projects/${created.project.id}/tasks`);
+    assert.equal(tasksResponse.status, 200);
+    const tasks = await tasksResponse.json();
+    assert.deepEqual(tasks.tasks, []);
+  } finally {
+    context.server.close();
+    context.storage.close();
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- rewrite the README with a clear purpose statement, current roadmap status, and updated configuration guidance
- add configuration drift detection utilities with a new `imme config drift` command and supporting unit tests
- expand the web API/UI to create and update projects from the dashboard and cover it with integration tests

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df28dc622c832b987d8d28915c43d1