### PR TITLE
Add task management flows to web dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,6 @@ Launch the workspace dashboard with:
 npm run web
 ```
 
-Visit `http://localhost:3000` to view workspace health, projects, and tasks. The interface follows the provided palette and the Laws of UX for a focused, high-contrast experience. The dashboard now includes a project editor that can create new projects or update the currently selected project via the `/api/projects` POST and PUT endpoints. Use the Refresh button to sync the view after CLI-driven changes.
+Visit `http://localhost:3000` to view workspace health, projects, and tasks. The interface follows the provided palette and the Laws of UX for a focused, high-contrast experience. The dashboard now includes editors for both projects and tasks: create or update projects via the `/api/projects` POST and PUT endpoints, and manage per-project tasks directly from the inline task editor. Use the Refresh button to sync the view after CLI-driven changes.
 
 Refer to `docs/runbook.md` for operational procedures and `docs/onboarding.md` for contributor guidelines.

--- a/project-manager/task.md
+++ b/project-manager/task.md
@@ -18,6 +18,8 @@ This document tracks progress for the Imme project. Checkboxes reflect the curre
 - [x] Documented trade-offs between SQLite, PostgreSQL, and document stores.
 - [x] Automated configuration drift detection (notifies when `.imme/config.json` diverges across clones).
 - [x] Expanded the web API and UI to support creating and updating projects directly from the dashboard.
+- [x] Expanded the web API with task creation and update endpoints for the dashboard.
+- [x] Delivered an inline task editor that manages assignees, status, and notes from the web UI.
 
 ## 🔄 In Progress / Backlog
 

--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -4,6 +4,7 @@
 const state = {
   selectedProjectId: null,
   editorProjectId: null,
+  editorTaskId: null,
   projects: [],
   tasks: []
 };
@@ -16,7 +17,9 @@ const fields = {
   updated: document.querySelector('[data-field="workspace-updated"]'),
   tasksContext: document.querySelector('[data-field="tasks-context"]'),
   editorMode: document.querySelector('[data-field="editor-mode"]'),
-  projectFeedback: document.querySelector('[data-field="project-feedback"]')
+  projectFeedback: document.querySelector('[data-field="project-feedback"]'),
+  taskEditorMode: document.querySelector('[data-field="task-editor-mode"]'),
+  taskFeedback: document.querySelector('[data-field="task-feedback"]')
 };
 
 const elements = {
@@ -28,8 +31,17 @@ const elements = {
   projectDescription: document.querySelector('[name="project-description"]'),
   projectStatus: document.querySelector('[name="project-status"]'),
   projectReset: document.querySelector('[data-action="reset-editor"]'),
-  projectSubmit: document.querySelector('[data-action="submit-project"]')
+  projectSubmit: document.querySelector('[data-action="submit-project"]'),
+  taskForm: document.querySelector('.task-form'),
+  taskTitle: document.querySelector('[name="task-title"]'),
+  taskStatus: document.querySelector('[name="task-status"]'),
+  taskAssignees: document.querySelector('[name="task-assignees"]'),
+  taskNotes: document.querySelector('[name="task-notes"]'),
+  taskSubmit: document.querySelector('[data-action="submit-task"]'),
+  taskReset: document.querySelector('[data-action="reset-task"]')
 };
+
+let taskFormBusy = false;
 
 async function fetchJson(url) {
   const response = await fetch(url);
@@ -88,6 +100,7 @@ function setEditorProject(project) {
 function resetProjectEditor() {
   setEditorProject(null);
   clearProjectFeedback();
+  resetTaskEditor();
 }
 
 function clearProjectFeedback() {
@@ -169,6 +182,7 @@ function renderTasks(tasks) {
   elements.taskList.innerHTML = '';
   if (!state.selectedProjectId) {
     fields.tasksContext.textContent = 'Choose a project to load its tasks.';
+    updateTaskEditorModeCopy();
     return;
   }
 
@@ -178,6 +192,7 @@ function renderTasks(tasks) {
     empty.className = 'empty-state';
     empty.textContent = 'Tasks will appear here once they are added to the project.';
     elements.taskList.appendChild(empty);
+    updateTaskEditorModeCopy();
     return;
   }
 
@@ -186,6 +201,14 @@ function renderTasks(tasks) {
   for (const task of tasks) {
     const item = document.createElement('li');
     item.className = 'task-card';
+    if (task.id === state.editorTaskId) {
+      item.classList.add('active');
+    }
+
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.setAttribute('data-task-id', task.id);
+    button.addEventListener('click', () => setTaskEditor(task));
 
     const heading = document.createElement('h3');
     heading.textContent = task.title;
@@ -198,17 +221,28 @@ function renderTasks(tasks) {
     const notes = document.createElement('p');
     notes.textContent = task.notes || 'No notes yet.';
 
-    item.append(heading, status);
+    button.append(heading, status, notes);
 
     if (task.assignees?.length) {
       const assignees = document.createElement('p');
       assignees.textContent = `Assigned to: ${task.assignees.join(', ')}`;
-      item.append(assignees);
+      button.append(assignees);
     }
 
-    item.append(notes);
+    item.append(button);
     elements.taskList.appendChild(item);
   }
+
+  updateTaskEditorModeCopy();
+}
+
+function showTasksLoadingState() {
+  if (!fields.tasksContext || !elements.taskList) {
+    return;
+  }
+
+  fields.tasksContext.textContent = 'Loading tasks…';
+  elements.taskList.innerHTML = '';
 }
 
 async function loadWorkspace() {
@@ -221,6 +255,7 @@ async function loadProjects() {
   state.projects = projects;
   if (state.selectedProjectId && !projects.some((project) => project.id === state.selectedProjectId)) {
     state.selectedProjectId = null;
+    state.tasks = [];
     resetProjectEditor();
   } else if (state.editorProjectId) {
     const project = projects.find((item) => item.id === state.editorProjectId);
@@ -233,6 +268,7 @@ async function loadProjects() {
     updateEditorModeCopy();
   }
   renderProjects(projects);
+  syncTaskFormEnabled();
   if (state.selectedProjectId) {
     await loadTasks(state.selectedProjectId);
   } else {
@@ -248,11 +284,15 @@ async function loadTasks(projectId) {
 
 async function selectProject(projectId) {
   state.selectedProjectId = projectId;
+  state.tasks = [];
+  showTasksLoadingState();
+  resetTaskEditor({ skipRender: true });
   const project = state.projects.find((item) => item.id === projectId);
   if (project) {
     setEditorProject(project);
   }
   renderProjects(state.projects);
+  syncTaskFormEnabled();
   await loadTasks(projectId);
 }
 
@@ -319,6 +359,194 @@ async function handleProjectSubmit(event) {
   }
 }
 
+function parseAssigneesInput(value) {
+  if (!value) {
+    return [];
+  }
+
+  return value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+function populateTaskEditorFields(task) {
+  if (!elements.taskForm) {
+    return;
+  }
+
+  elements.taskTitle.value = task?.title ?? '';
+  elements.taskStatus.value = task?.status ?? 'todo';
+  elements.taskAssignees.value = task?.assignees?.join(', ') ?? '';
+  elements.taskNotes.value = task?.notes ?? '';
+}
+
+function updateTaskEditorModeCopy() {
+  if (!fields.taskEditorMode || !elements.taskSubmit) {
+    return;
+  }
+
+  if (!state.selectedProjectId) {
+    fields.taskEditorMode.textContent = 'Select a project to enable the task editor.';
+    return;
+  }
+
+  if (state.editorTaskId) {
+    fields.taskEditorMode.textContent = 'Editing an existing task. Save to persist your updates.';
+    elements.taskSubmit.textContent = 'Update Task';
+    if (elements.taskReset) {
+      elements.taskReset.textContent = 'Switch to Create Mode';
+    }
+  } else {
+    fields.taskEditorMode.textContent = 'Create a new task for the selected project.';
+    elements.taskSubmit.textContent = 'Create Task';
+    if (elements.taskReset) {
+      elements.taskReset.textContent = 'Clear';
+    }
+  }
+}
+
+function clearTaskFeedback() {
+  if (!fields.taskFeedback) {
+    return;
+  }
+  fields.taskFeedback.textContent = '';
+  delete fields.taskFeedback.dataset.variant;
+}
+
+function showTaskFeedback(message, variant = 'info') {
+  if (!fields.taskFeedback) {
+    return;
+  }
+  fields.taskFeedback.textContent = message;
+  fields.taskFeedback.dataset.variant = variant;
+}
+
+function syncTaskFormEnabled() {
+  if (!elements.taskForm) {
+    return;
+  }
+
+  const shouldEnable = Boolean(state.selectedProjectId) && !taskFormBusy;
+  const controls = elements.taskForm.querySelectorAll('input, textarea, select, button');
+  for (const control of controls) {
+    control.disabled = !shouldEnable;
+  }
+
+  if (shouldEnable) {
+    elements.taskForm.removeAttribute('aria-disabled');
+  } else {
+    elements.taskForm.setAttribute('aria-disabled', 'true');
+  }
+}
+
+function setTaskFormBusy(isBusy) {
+  if (!elements.taskForm) {
+    return;
+  }
+  taskFormBusy = isBusy;
+  if (isBusy) {
+    elements.taskForm.setAttribute('aria-busy', 'true');
+  } else {
+    elements.taskForm.removeAttribute('aria-busy');
+  }
+  syncTaskFormEnabled();
+}
+
+function setTaskEditor(task) {
+  state.editorTaskId = task?.id ?? null;
+  populateTaskEditorFields(task ?? null);
+  clearTaskFeedback();
+  updateTaskEditorModeCopy();
+  renderTasks(state.tasks);
+}
+
+function resetTaskEditor({ skipRender = false } = {}) {
+  state.editorTaskId = null;
+  populateTaskEditorFields(null);
+  clearTaskFeedback();
+  updateTaskEditorModeCopy();
+  syncTaskFormEnabled();
+  if (!skipRender) {
+    renderTasks(state.tasks);
+  }
+}
+
+async function handleTaskSubmit(event) {
+  event.preventDefault();
+  clearTaskFeedback();
+
+  if (!state.selectedProjectId) {
+    showTaskFeedback('Select a project before creating tasks.', 'error');
+    return;
+  }
+
+  const title = elements.taskTitle.value.trim();
+  if (!title) {
+    showTaskFeedback('Task title is required.', 'error');
+    elements.taskTitle.focus();
+    return;
+  }
+
+  const payload = {
+    title,
+    status: elements.taskStatus.value,
+    assignees: parseAssigneesInput(elements.taskAssignees.value),
+    notes: elements.taskNotes.value
+  };
+
+  const endpoint = state.editorTaskId
+    ? `/api/tasks/${state.editorTaskId}`
+    : `/api/projects/${state.selectedProjectId}/tasks`;
+  const method = state.editorTaskId ? 'PUT' : 'POST';
+
+  setTaskFormBusy(true);
+
+  try {
+    const response = await fetch(endpoint, {
+      method,
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(payload)
+    });
+
+    let result = {};
+    try {
+      result = await response.json();
+    } catch {
+      result = {};
+    }
+
+    if (!response.ok) {
+      throw new Error(result.error ?? `Request failed with status ${response.status}`);
+    }
+
+    if (!result.task) {
+      throw new Error('Unexpected API response: missing task payload.');
+    }
+
+    const successMessage = state.editorTaskId ? 'Task updated successfully.' : 'Task created successfully.';
+    showTaskFeedback(successMessage, 'success');
+
+    state.editorTaskId = result.task.id;
+    populateTaskEditorFields(result.task);
+    updateTaskEditorModeCopy();
+
+    try {
+      await loadTasks(state.selectedProjectId);
+    } catch (refreshError) {
+      console.error('Task saved but refresh failed:', refreshError);
+      showTaskFeedback(`${successMessage} Refresh failed: ${refreshError.message}`, 'warning');
+    }
+  } catch (error) {
+    console.error('Task submission failed:', error);
+    showTaskFeedback(error.message, 'error');
+  } finally {
+    setTaskFormBusy(false);
+  }
+}
+
 async function refresh() {
   try {
     elements.refresh.setAttribute('aria-busy', 'true');
@@ -348,7 +576,25 @@ if (elements.projectReset) {
   });
 }
 
+if (elements.taskForm) {
+  elements.taskForm.addEventListener('submit', handleTaskSubmit);
+}
+
+if (elements.taskReset) {
+  elements.taskReset.addEventListener('click', (event) => {
+    event.preventDefault();
+    if (state.editorTaskId) {
+      resetTaskEditor();
+    } else {
+      populateTaskEditorFields(null);
+      clearTaskFeedback();
+      updateTaskEditorModeCopy();
+    }
+  });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   resetProjectEditor();
+  resetTaskEditor();
   refresh();
 });

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -109,8 +109,61 @@
           <p class="section-subtitle" data-field="tasks-context">
             Choose a project to load its tasks.
           </p>
+          <p class="section-subtitle" data-field="task-editor-mode">
+            Select a project to enable the task editor.
+          </p>
         </div>
         <ul class="task-list" role="list" aria-live="polite"></ul>
+        <form class="task-form" autocomplete="off" novalidate>
+          <div class="field-group">
+            <label>
+              <span>Task title</span>
+              <input
+                type="text"
+                name="task-title"
+                required
+                maxlength="160"
+                placeholder="e.g., Draft deployment checklist"
+              />
+            </label>
+          </div>
+          <div class="field-group">
+            <label>
+              <span>Status</span>
+              <select name="task-status">
+                <option value="todo">To Do</option>
+                <option value="in_progress">In Progress</option>
+                <option value="blocked">Blocked</option>
+                <option value="done">Done</option>
+              </select>
+            </label>
+          </div>
+          <div class="field-group">
+            <label>
+              <span>Assignees</span>
+              <input
+                type="text"
+                name="task-assignees"
+                placeholder="Comma-separated names"
+              />
+            </label>
+          </div>
+          <div class="field-group">
+            <label>
+              <span>Notes</span>
+              <textarea
+                name="task-notes"
+                rows="3"
+                placeholder="Context, blockers, or next steps"
+              ></textarea>
+            </label>
+          </div>
+          <div class="form-actions">
+            <button type="submit" data-action="submit-task">Create Task</button>
+            <button type="button" data-action="reset-task">Clear</button>
+          </div>
+        </form>
+        <p class="form-feedback" data-field="task-feedback" role="status" aria-live="polite"></p>
       </section>
     </main>
     <footer class="app-footer">

--- a/src/web/public/styles.css
+++ b/src/web/public/styles.css
@@ -133,7 +133,8 @@ body {
   gap: 1rem;
 }
 
-.project-form {
+.project-form,
+.task-form {
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -231,22 +232,31 @@ body {
   position: relative;
 }
 
-.project-card button {
+.project-card button,
+.task-card button {
   all: unset;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
   cursor: pointer;
+  width: 100%;
 }
 
 .project-card:hover,
-.project-card:focus-within {
+.project-card:focus-within,
+.task-card:hover,
+.task-card:focus-within {
   transform: translateY(-4px);
   border-color: rgba(234, 240, 236, 0.35);
   background: rgba(86, 90, 123, 0.75);
 }
 
 .project-card.active {
+  border-color: rgba(210, 216, 249, 0.8);
+  box-shadow: 0 0 0 3px rgba(210, 216, 249, 0.2);
+}
+
+.task-card.active {
   border-color: rgba(210, 216, 249, 0.8);
   box-shadow: 0 0 0 3px rgba(210, 216, 249, 0.2);
 }
@@ -297,6 +307,10 @@ body {
 
 .task-card .status-pill {
   margin-top: 0.5rem;
+}
+
+.task-form[aria-disabled="true"] {
+  opacity: 0.6;
 }
 
 .empty-state {

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -96,6 +96,56 @@ async function readJsonBody(req) {
   return parsed;
 }
 
+function normalizeTaskTitle(value) {
+  if (typeof value !== "string") {
+    throw new Error("Task title is required");
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error("Task title is required");
+  }
+
+  return trimmed;
+}
+
+function normalizeOptionalString(value, fieldName) {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === null) {
+    return "";
+  }
+
+  if (typeof value !== "string") {
+    throw new Error(`${fieldName} must be a string`);
+  }
+
+  return value;
+}
+
+function parseAssignees(value) {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === null) {
+    return [];
+  }
+
+  if (!Array.isArray(value)) {
+    throw new Error("assignees must be an array of strings");
+  }
+
+  const invalidEntry = value.find((entry) => typeof entry !== "string");
+  if (invalidEntry !== undefined) {
+    throw new Error("assignees must be an array of strings");
+  }
+
+  return value.map((entry) => entry.trim()).filter((entry) => entry.length > 0);
+}
+
 export function start({
   port = DEFAULT_PORT,
   workspaceResolver = loadWorkspaceSummary,
@@ -129,6 +179,11 @@ export function start({
 
       if (pathname.startsWith("/api/projects")) {
         await handleProjectsApi({ req, res, pathname, storage, logger });
+        return;
+      }
+
+      if (pathname.startsWith("/api/tasks")) {
+        await handleTasksApi({ req, res, pathname, storage, logger });
         return;
       }
 
@@ -211,9 +266,47 @@ async function handleProjectsApi({ req, res, pathname, storage, logger }) {
 
   if (segments.length === 4 && segments[3] === "tasks") {
     const projectId = segments[2];
-    const tasks = storage.listTasksByProject(projectId);
-    sendJson(res, 200, { tasks });
-    return;
+    if (req.method === "GET") {
+      const tasks = storage.listTasksByProject(projectId);
+      sendJson(res, 200, { tasks });
+      return;
+    }
+
+    if (req.method === "POST") {
+      let body;
+      try {
+        body = await readJsonBody(req);
+      } catch (error) {
+        sendJson(res, 400, { error: error.message });
+        return;
+      }
+
+      try {
+        const title = normalizeTaskTitle(body.title);
+        const status = typeof body.status === "string" ? body.status : undefined;
+        const assignees = parseAssignees(body.assignees);
+        const notes = normalizeOptionalString(body.notes, "notes");
+        const task = storage.createTask({
+          projectId,
+          title,
+          status,
+          assignees: assignees ?? [],
+          notes: notes ?? ""
+        });
+        sendJson(res, 201, { task });
+        return;
+      } catch (error) {
+        logger.error({
+          functionName: "handleProjectsApi",
+          message: error.message,
+          error,
+          systemSection: "api",
+          method: "POST"
+        });
+        sendJson(res, 400, { error: error.message });
+        return;
+      }
+    }
   }
 
   if (segments.length === 3 && req.method === "PUT") {
@@ -258,6 +351,60 @@ async function handleProjectsApi({ req, res, pathname, storage, logger }) {
 async function handleWorkspaceApi({ res, workspaceResolver }) {
   const { workspace } = workspaceResolver();
   sendJson(res, 200, { workspace });
+}
+
+async function handleTasksApi({ req, res, pathname, storage, logger }) {
+  const segments = pathname.split("/").filter(Boolean);
+  if (segments.length === 3 && req.method === "PUT") {
+    const taskId = segments[2];
+    let body;
+    try {
+      body = await readJsonBody(req);
+    } catch (error) {
+      sendJson(res, 400, { error: error.message });
+      return;
+    }
+
+    try {
+      const payload = {};
+      if (Object.prototype.hasOwnProperty.call(body, "title")) {
+        payload.title = normalizeTaskTitle(body.title);
+      }
+      if (Object.prototype.hasOwnProperty.call(body, "status")) {
+        payload.status = typeof body.status === "string" ? body.status : undefined;
+      }
+      if (Object.prototype.hasOwnProperty.call(body, "assignees")) {
+        payload.assignees = parseAssignees(body.assignees);
+      }
+      if (Object.prototype.hasOwnProperty.call(body, "notes")) {
+        payload.notes = normalizeOptionalString(body.notes, "notes");
+      }
+
+      if (Object.keys(payload).length === 0) {
+        throw new Error("No task fields provided for update");
+      }
+
+      const task = storage.updateTask({ id: taskId, ...payload });
+      sendJson(res, 200, { task });
+      return;
+    } catch (error) {
+      logger.error({
+        functionName: "handleTasksApi",
+        message: error.message,
+        error,
+        systemSection: "api",
+        method: req.method ?? "NONE"
+      });
+      if (/does not exist/i.test(error.message)) {
+        sendJson(res, 404, { error: error.message });
+      } else {
+        sendJson(res, 400, { error: error.message });
+      }
+      return;
+    }
+  }
+
+  sendJson(res, 404, { error: "Not Found" });
 }
 
 async function handleStatic({ pathname, res, publicDir }) {

--- a/test/web-server.test.js
+++ b/test/web-server.test.js
@@ -88,3 +88,79 @@ test("web API allows creating and updating projects", async () => {
     rmSync(tempDir, { recursive: true, force: true });
   }
 });
+
+test("web API allows creating and updating tasks", async () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "imme-web-"));
+  const workspaceSummary = createWorkspaceContext(tempDir);
+  const logger = createLoggerStub();
+
+  const context = start({
+    port: 0,
+    workspaceResolver: () => workspaceSummary,
+    loggerFactory: () => logger,
+    publicDir: resolve(process.cwd(), "src", "web", "public")
+  });
+
+  try {
+    await once(context.server, "listening");
+    const address = context.server.address();
+    assert.ok(address && typeof address === "object");
+    const baseUrl = `http://127.0.0.1:${address.port}`;
+
+    const createProjectResponse = await fetch(`${baseUrl}/api/projects`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Task Suite", description: "Verify tasks", status: "active" })
+    });
+    assert.equal(createProjectResponse.status, 201);
+    const { project } = await createProjectResponse.json();
+    assert.ok(project.id);
+
+    const createTaskResponse = await fetch(`${baseUrl}/api/projects/${project.id}/tasks`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "Outline requirements",
+        status: "todo",
+        notes: "Draft acceptance criteria",
+        assignees: ["casey", "drew"]
+      })
+    });
+    assert.equal(createTaskResponse.status, 201);
+    const created = await createTaskResponse.json();
+    assert.ok(created.task.id);
+    assert.equal(created.task.projectId, project.id);
+    assert.deepEqual(created.task.assignees, ["casey", "drew"]);
+
+    const listResponse = await fetch(`${baseUrl}/api/projects/${project.id}/tasks`);
+    assert.equal(listResponse.status, 200);
+    const listed = await listResponse.json();
+    assert.equal(listed.tasks.length, 1);
+    assert.equal(listed.tasks[0].title, "Outline requirements");
+
+    const updateTaskResponse = await fetch(`${baseUrl}/api/tasks/${created.task.id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        status: "in_progress",
+        notes: "Working through details",
+        assignees: ["drew"]
+      })
+    });
+    assert.equal(updateTaskResponse.status, 200);
+    const updated = await updateTaskResponse.json();
+    assert.equal(updated.task.status, "in_progress");
+    assert.deepEqual(updated.task.assignees, ["drew"]);
+    assert.equal(updated.task.notes, "Working through details");
+
+    const refreshResponse = await fetch(`${baseUrl}/api/projects/${project.id}/tasks`);
+    assert.equal(refreshResponse.status, 200);
+    const refreshed = await refreshResponse.json();
+    assert.equal(refreshed.tasks.length, 1);
+    assert.equal(refreshed.tasks[0].status, "in_progress");
+  } finally {
+    context.server.close();
+    context.storage.close();
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- extend the web server with validated endpoints for creating and updating project tasks
- add a task editor to the dashboard with inline status, assignee, and notes controls plus refreshed styles
- document the new task management workflows and record the completed roadmap items

## Testing
- npm run lint
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68df31b46254832ba07ccada69799ccb