### PR TITLE
Add task deletion flows to web dashboard

### DIFF
--- a/project-manager/task.md
+++ b/project-manager/task.md
@@ -20,6 +20,7 @@ This document tracks progress for the Imme project. Checkboxes reflect the curre
 - [x] Expanded the web API and UI to support creating and updating projects directly from the dashboard.
 - [x] Expanded the web API with task creation and update endpoints for the dashboard.
 - [x] Delivered an inline task editor that manages assignees, status, and notes from the web UI.
+- [x] Enabled task deletion across the API and dashboard so teams can retire completed work.
 
 ## 🔄 In Progress / Backlog
 

--- a/src/storage/sqlite.js
+++ b/src/storage/sqlite.js
@@ -322,7 +322,11 @@ export class SQLiteStorage {
       throw new Error("Task id is required");
     }
 
-    this.#statements.deleteTask.run(id);
+    const result = this.#statements.deleteTask.run(id);
+    if (!result || result.changes === 0) {
+      throw new Error(`Task ${id} does not exist`);
+    }
+
     this.#log("INFO", {
       functionName: "deleteTask",
       message: `Deleted task ${id}`,

--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -1,5 +1,5 @@
 /* eslint-env browser */
-/* global document, fetch */
+/* global document, fetch, window */
 
 const state = {
   selectedProjectId: null,
@@ -38,7 +38,8 @@ const elements = {
   taskAssignees: document.querySelector('[name="task-assignees"]'),
   taskNotes: document.querySelector('[name="task-notes"]'),
   taskSubmit: document.querySelector('[data-action="submit-task"]'),
-  taskReset: document.querySelector('[data-action="reset-task"]')
+  taskReset: document.querySelector('[data-action="reset-task"]'),
+  taskDelete: document.querySelector('[data-action="delete-task"]')
 };
 
 let taskFormBusy = false;
@@ -438,6 +439,10 @@ function syncTaskFormEnabled() {
   } else {
     elements.taskForm.setAttribute('aria-disabled', 'true');
   }
+
+  if (elements.taskDelete) {
+    elements.taskDelete.disabled = !shouldEnable || !state.editorTaskId;
+  }
 }
 
 function setTaskFormBusy(isBusy) {
@@ -459,6 +464,7 @@ function setTaskEditor(task) {
   clearTaskFeedback();
   updateTaskEditorModeCopy();
   renderTasks(state.tasks);
+  syncTaskFormEnabled();
 }
 
 function resetTaskEditor({ skipRender = false } = {}) {
@@ -547,6 +553,52 @@ async function handleTaskSubmit(event) {
   }
 }
 
+async function handleTaskDelete(event) {
+  event.preventDefault();
+  clearTaskFeedback();
+
+  if (!state.selectedProjectId || !state.editorTaskId) {
+    showTaskFeedback('Select an existing task before deleting.', 'error');
+    return;
+  }
+
+  const confirmed = window.confirm('Delete this task? This action cannot be undone.');
+  if (!confirmed) {
+    return;
+  }
+
+  setTaskFormBusy(true);
+
+  try {
+    const response = await fetch(`/api/tasks/${state.editorTaskId}`, {
+      method: 'DELETE'
+    });
+
+    if (response.status === 404) {
+      throw new Error('Task not found. It may have already been deleted.');
+    }
+
+    if (!response.ok) {
+      throw new Error(`Request failed with status ${response.status}`);
+    }
+
+    showTaskFeedback('Task deleted successfully.', 'success');
+    resetTaskEditor({ skipRender: true });
+
+    try {
+      await loadTasks(state.selectedProjectId);
+    } catch (refreshError) {
+      console.error('Task deleted but refresh failed:', refreshError);
+      showTaskFeedback(`Task deleted. Refresh failed: ${refreshError.message}`, 'warning');
+    }
+  } catch (error) {
+    console.error('Task deletion failed:', error);
+    showTaskFeedback(error.message, 'error');
+  } finally {
+    setTaskFormBusy(false);
+  }
+}
+
 async function refresh() {
   try {
     elements.refresh.setAttribute('aria-busy', 'true');
@@ -591,6 +643,10 @@ if (elements.taskReset) {
       updateTaskEditorModeCopy();
     }
   });
+}
+
+if (elements.taskDelete) {
+  elements.taskDelete.addEventListener('click', handleTaskDelete);
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -161,6 +161,7 @@
           <div class="form-actions">
             <button type="submit" data-action="submit-task">Create Task</button>
             <button type="button" data-action="reset-task">Clear</button>
+            <button type="button" data-action="delete-task" data-variant="danger">Delete Task</button>
           </div>
         </form>
         <p class="form-feedback" data-field="task-feedback" role="status" aria-live="polite"></p>

--- a/src/web/public/styles.css
+++ b/src/web/public/styles.css
@@ -196,11 +196,23 @@ body {
   background: var(--color-surface-alt);
 }
 
+.form-actions button[data-variant="danger"] {
+  background: rgba(255, 105, 135, 0.8);
+  color: #1f0f1f;
+}
+
 .form-actions button:hover,
 .form-actions button:focus-visible {
   transform: translateY(-2px);
   box-shadow: 0 12px 18px rgba(0, 0, 0, 0.2);
   outline: none;
+}
+
+.form-actions button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
 }
 
 .form-feedback {

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -404,6 +404,32 @@ async function handleTasksApi({ req, res, pathname, storage, logger }) {
     }
   }
 
+  if (segments.length === 3 && req.method === "DELETE") {
+    const taskId = segments[2];
+
+    try {
+      storage.deleteTask(taskId);
+      res.statusCode = 204;
+      res.end();
+      return;
+    } catch (error) {
+      logger.error({
+        functionName: "handleTasksApi",
+        message: error.message,
+        error,
+        systemSection: "api",
+        method: "DELETE"
+      });
+
+      if (/does not exist/i.test(error.message)) {
+        sendJson(res, 404, { error: error.message });
+      } else {
+        sendJson(res, 400, { error: error.message });
+      }
+      return;
+    }
+  }
+
   sendJson(res, 404, { error: "Not Found" });
 }
 

--- a/test/sqlite-storage.test.js
+++ b/test/sqlite-storage.test.js
@@ -49,5 +49,14 @@ test("SQLiteStorage persists projects and tasks", () => {
 
     const tasks = storage.listTasksByProject(project.id);
     assert.equal(tasks.length, 1);
+
+    storage.deleteTask(task.id);
+    const afterDelete = storage.listTasksByProject(project.id);
+    assert.equal(afterDelete.length, 0);
+    assert.equal(storage.getTaskById(task.id), null);
+
+    assert.throws(() => {
+      storage.deleteTask(task.id);
+    }, /does not exist/);
   });
 });

--- a/test/web-server.test.js
+++ b/test/web-server.test.js
@@ -158,6 +158,21 @@ test("web API allows creating and updating tasks", async () => {
     const refreshed = await refreshResponse.json();
     assert.equal(refreshed.tasks.length, 1);
     assert.equal(refreshed.tasks[0].status, "in_progress");
+
+    const deleteTaskResponse = await fetch(`${baseUrl}/api/tasks/${created.task.id}`, {
+      method: "DELETE"
+    });
+    assert.equal(deleteTaskResponse.status, 204);
+
+    const afterDeleteResponse = await fetch(`${baseUrl}/api/projects/${project.id}/tasks`);
+    assert.equal(afterDeleteResponse.status, 200);
+    const afterDelete = await afterDeleteResponse.json();
+    assert.equal(afterDelete.tasks.length, 0);
+
+    const missingDeleteResponse = await fetch(`${baseUrl}/api/tasks/${created.task.id}`, {
+      method: "DELETE"
+    });
+    assert.equal(missingDeleteResponse.status, 404);
   } finally {
     context.server.close();
     context.storage.close();


### PR DESCRIPTION
## Summary
- add a DELETE handler for task records and tighten SQLiteStorage.deleteTask error handling
- surface task deletion controls in the dashboard with new UI states and styling
- cover the new behavior with storage and web API tests and record the completed roadmap item

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df379d67f0832bbd02ef8b8e79ac05